### PR TITLE
Acceptance tests for custom email template resource

### DIFF
--- a/internal/provider/resources/b2bsdkconfig.go
+++ b/internal/provider/resources/b2bsdkconfig.go
@@ -511,6 +511,9 @@ func (r *b2bSDKConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resources/consumersdkconfig.go
+++ b/internal/provider/resources/consumersdkconfig.go
@@ -574,6 +574,9 @@ func (r *consumerSDKConfigResource) Schema(_ context.Context, _ resource.SchemaR
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resources/emailtemplate.go
+++ b/internal/provider/resources/emailtemplate.go
@@ -271,7 +271,6 @@ func (m *emailTemplateModel) reloadFromEmailTemplate(ctx context.Context, e emai
 	var diags diag.Diagnostics
 
 	if e.SenderInformation != nil {
-		// TODO: If a value was previously set and is now null, it meant the sender info wasn't valid and did not get set
 		newSenderInfo := emailTemplateSenderInformationModelFromEmailTemplate(e)
 		diags.Append(m.compareSenderInfo(ctx, newSenderInfo)...)
 		senderInformation, diag := types.ObjectValueFrom(ctx, emailTemplateSenderInformationModel{}.AttributeTypes(), newSenderInfo)

--- a/internal/provider/resources/emailtemplate_test.go
+++ b/internal/provider/resources/emailtemplate_test.go
@@ -1,21 +1,29 @@
 package resources_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stytchauth/terraform-provider-stytch/internal/provider/testutil"
 )
 
+type emailTemplateTestCase struct {
+	testutil.TestCase
+	shouldSkip bool
+}
+
 func TestAccEmailTemplateResource(t *testing.T) {
-	for _, testCase := range []testutil.TestCase{
+	customDomain := os.Getenv("STYTCH_CUSTOM_DOMAIN")
+	for _, testCase := range []emailTemplateTestCase{
 		{
-			Name: "prebuilt",
-			Config: testutil.ConsumerProjectConfig + `
+			TestCase: testutil.TestCase{
+				Name: "prebuilt",
+				Config: testutil.ConsumerProjectConfig + `
         resource "stytch_email_template" "test" {
           live_project_id = stytch_project.project.live_project_id
-          template_id = "tf-test"
-          name = "tf-test"
+          template_id = "tf-test-prebuilt"
+          name = "tf-test-prebuilt"
           prebuilt_customization = {
             button_border_radius = 3
             button_color         = "#105ee9"
@@ -24,18 +32,101 @@ func TestAccEmailTemplateResource(t *testing.T) {
             text_alignment       = "CENTER"
           }
         }`,
-			Checks: []resource.TestCheckFunc{
-				resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test"),
-				resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test"),
-				resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.button_border_radius", "3"),
-				resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.button_color", "#105ee9"),
-				resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.button_text_color", "#ffffff"),
-				resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.font_family", "GEORGIA"),
-				resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.text_alignment", "CENTER"),
+				Checks: []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-prebuilt"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-prebuilt"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.button_border_radius", "3"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.button_color", "#105ee9"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.button_text_color", "#ffffff"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.font_family", "GEORGIA"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.text_alignment", "CENTER"),
+				},
 			},
+			shouldSkip: false,
+		},
+		{
+			TestCase: testutil.TestCase{
+				Name: "prebuilt-with-sender",
+				Config: testutil.ConsumerProjectConfig + `
+      resource "stytch_email_template" "test" {
+        live_project_id = stytch_project.project.live_project_id
+        template_id = "tf-test-prebuilt2"
+        name = "tf-test-prebuilt2"
+        sender_information = {
+          from_local_part = "noreply"
+          from_domain = "` + customDomain + `"
+          from_name = "Stytch"
+          reply_to_local_part = "support"
+          reply_to_name = "Support"
+        }
+        prebuilt_customization = {
+          button_border_radius = 3
+          button_color         = "#105ee9"
+          button_text_color    = "#ffffff"
+          font_family          = "GEORGIA"
+          text_alignment       = "CENTER"
+        }
+      }`,
+				Checks: []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-prebuilt2"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-prebuilt2"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_local_part", "noreply"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_domain", customDomain),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_name", "Stytch"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_local_part", "support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_name", "Support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.button_border_radius", "3"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.button_color", "#105ee9"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.button_text_color", "#ffffff"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.font_family", "GEORGIA"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "prebuilt_customization.text_alignment", "CENTER"),
+				},
+			},
+			shouldSkip: customDomain == "",
+		},
+		{
+			TestCase: testutil.TestCase{
+				Name: "custom",
+				Config: testutil.ConsumerProjectConfig + `
+      resource "stytch_email_template" "test" {
+        live_project_id = stytch_project.project.live_project_id
+        template_id = "tf-test-custom"
+        name = "tf-test-custom"
+        sender_information = {
+          from_local_part = "noreply"
+          from_domain = "` + customDomain + `"
+          from_name = "Stytch"
+          reply_to_local_part = "support"
+          reply_to_name = "Support"
+        }
+        custom_html_customization = {
+          template_type = "LOGIN"
+          html_content = "<h1>Login now: {{magic_link_url}}</h1>"
+          plaintext_content = "Login now: {{magic_link_url}}"
+          subject = "Login to ` + customDomain + `"
+        }
+      }`,
+				Checks: []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-custom"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-custom"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_local_part", "noreply"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_domain", customDomain),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_name", "Stytch"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_local_part", "support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_name", "Support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.template_type", "LOGIN"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.html_content", "<h1>Login now: {{magic_link_url}}</h1>"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.plaintext_content", "Login now: {{magic_link_url}}"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.subject", "Login to "+customDomain),
+				},
+			},
+			shouldSkip: customDomain == "",
 		},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.shouldSkip {
+				t.Skip("Skipping test due to missing STYTCH_CUSTOM_DOMAIN environment variable")
+			}
 			resource.Test(t, resource.TestCase{
 				ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
 				Steps: []resource.TestStep{

--- a/internal/provider/resources/passwordconfig.go
+++ b/internal/provider/resources/passwordconfig.go
@@ -89,6 +89,9 @@ func (r *passwordConfigResource) Schema(_ context.Context, _ resource.SchemaRequ
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/resources/project.go
+++ b/internal/provider/resources/project.go
@@ -90,6 +90,9 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"live_project_id": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resources/rbacpolicy.go
+++ b/internal/provider/resources/rbacpolicy.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -344,6 +346,9 @@ func (r *rbacPolicyResource) Schema(_ context.Context, _ resource.SchemaRequest,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				Required:    true,

--- a/main.go
+++ b/main.go
@@ -26,9 +26,6 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		// TODO: Update this string with the published name of your provider.
-		// Also update the tfplugindocs generate command to either remove the
-		// -provider-name flag or set its value to the updated provider name.
 		Address: "registry.terraform.io/stytchauth/stytch",
 		Debug:   debug,
 	}


### PR DESCRIPTION
Adds more complex test cases for email templates, including sender info and custom HTML templates. This requires a custom domain to be configured first and then set via the STYTCH_CUSTOM_DOMAIN environment variable. If not set, these tests are skipped.

Fixes BACK-3800