### PR TITLE
[RedirectURLs] Use DoNotPromoteDefaults to avoid inconsistency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.25.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.11.0
-	github.com/stytchauth/stytch-management-go v1.1.0
+	github.com/stytchauth/stytch-management-go v1.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/stytchauth/stytch-management-go v1.0.2 h1:O9XA2uSkcoqbAlDHc+XOfkaaCkh
 github.com/stytchauth/stytch-management-go v1.0.2/go.mod h1:Y3NUMXprecfJNd61q2cDCEn9J60BHjd3DZcjoKO4OtE=
 github.com/stytchauth/stytch-management-go v1.1.0 h1:oTp3OQpB6ewzZb/LLXHHY6ctrrC5PgbHdcPqll237xA=
 github.com/stytchauth/stytch-management-go v1.1.0/go.mod h1:Y3NUMXprecfJNd61q2cDCEn9J60BHjd3DZcjoKO4OtE=
+github.com/stytchauth/stytch-management-go v1.2.0 h1:WPaYFpoxHFeUKRo5C2pjra0F60rjXMT4IztKNWWTAOs=
+github.com/stytchauth/stytch-management-go v1.2.0/go.mod h1:Y3NUMXprecfJNd61q2cDCEn9J60BHjd3DZcjoKO4OtE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resources/redirecturl.go
+++ b/internal/provider/resources/redirecturl.go
@@ -171,6 +171,10 @@ func (r *redirectURLResource) Create(ctx context.Context, req resource.CreateReq
 	createResp, err := r.client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
 		ProjectID:   plan.ProjectID.ValueString(),
 		RedirectURL: redirectURL,
+		// We explicitly disable default promotion logic because if the terraform provisioner specified that a redirect URL
+		// is *not* the default for a given type, if the API tries to override it to true, it will result in a provider
+		// inconsistency error.
+		DoNotPromoteDefaults: true,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create redirect URL", err.Error())
@@ -248,6 +252,10 @@ func (r *redirectURLResource) Update(ctx context.Context, req resource.UpdateReq
 	updateResp, err := r.client.RedirectURLs.Update(ctx, redirecturls.UpdateRequest{
 		ProjectID:   plan.ProjectID.ValueString(),
 		RedirectURL: redirectURL,
+		// We explicitly disable default promotion logic because if the terraform provisioner specified that a redirect URL
+		// is *not* the default for a given type, if the API tries to override it to true, it will result in a provider
+		// inconsistency error.
+		DoNotPromoteDefaults: true,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update redirect URL", err.Error())
@@ -280,6 +288,10 @@ func (r *redirectURLResource) Delete(ctx context.Context, req resource.DeleteReq
 	_, err := r.client.RedirectURLs.Delete(ctx, redirecturls.DeleteRequest{
 		ProjectID: state.ProjectID.ValueString(),
 		URL:       state.URL.ValueString(),
+		// We explicitly disable default promotion logic because if the terraform provisioner specified that a redirect URL
+		// is *not* the default for a given type, if the API tries to override it to true, it will result in a provider
+		// inconsistency error.
+		DoNotPromoteDefaults: true,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to delete redirect URL", err.Error())

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "0.1.0"
+const Version = "0.1.1"


### PR DESCRIPTION
Title. The comment also helps explain what's going on.

To test this, I ran the following terraform:

```tf
terraform {
  required_providers {
    stytch = {
      source = "registry.terraform.io/stytchauth/stytch"
    }
  }
}

resource "stytch_project" "consumer_project" {
  name     = "bug-report"
  vertical = "CONSUMER"
}

resource "stytch_redirect_url" "consumer_redirect_url_with_redirect" {
  project_id = stytch_project.consumer_project.live_project_id
  url        = "https://example.com/authenticate"
  valid_types = [
    {
      type       = "LOGIN"
      is_default = false
    },
    {
      type       = "SIGNUP"
      is_default = false
    }
  ]
}
```

_Before_ this PR, that resulted in the API overriding `is_default` and setting them to true. Now, it works as expected.

## Why didn't the existing acceptance tests catch this?
Our acceptance tests use **test** projects always -- which have a default URL assigned upon creation. But in live, no redirect URLs exist by default, which is how this bug surfaced.


```
🕙 15:32:50  ❯ terraform show
# stytch_project.consumer_project:
resource "stytch_project" "consumer_project" {
    created_at             = "2024-12-11T23:42:36Z"
    id                     = "project-live-1c8617f9-0d67-44dd-9731-0b5e91ece10f"
	/* snip */
}

# stytch_redirect_url.consumer_redirect_url_with_redirect:
resource "stytch_redirect_url" "consumer_redirect_url_with_redirect" {
    last_updated = "Wednesday, 11-Dec-24 15:42:36 PST"
    project_id   = "project-live-1c8617f9-0d67-44dd-9731-0b5e91ece10f"
    url          = "https://example.com/authenticate"
    valid_types  = [
        {
            is_default = false
            type       = "LOGIN"
        },
        {
            is_default = false
            type       = "SIGNUP"
        },
    ]
}
