### PR TITLE
Mark email template fields as computed

### DIFF
--- a/internal/provider/resources/emailtemplate.go
+++ b/internal/provider/resources/emailtemplate.go
@@ -383,22 +383,27 @@ func (r *emailTemplateResource) Schema(_ context.Context, _ resource.SchemaReque
 				Attributes: map[string]schema.Attribute{
 					"from_local_part": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The prefix of the sender’s email address, everything before the @ symbol (eg: first.last)",
 					},
 					"from_domain": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The postfix of the sender’s email address, everything after the @ symbol (eg: stytch.com)",
 					},
 					"from_name": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The sender of the email (eg: Login)",
 					},
 					"reply_to_local_part": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The prefix of the reply-to email address, everything before the @ symbol (eg: first.last)",
 					},
 					"reply_to_name": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The sender of the reply-to email address (eg: Support)",
 					},
 				},
@@ -413,18 +418,22 @@ func (r *emailTemplateResource) Schema(_ context.Context, _ resource.SchemaReque
 				Attributes: map[string]schema.Attribute{
 					"button_border_radius": schema.Float32Attribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The radius of the button border in the email body",
 					},
 					"button_color": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The color of the button in the email body",
 					},
 					"button_text_color": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The color of the text in the button in the email body",
 					},
 					"font_family": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The font type to be used in the email body",
 						Validators: []validator.String{
 							stringvalidator.OneOf(toStrings(emailtemplates.FontFamilies())...),
@@ -432,6 +441,7 @@ func (r *emailTemplateResource) Schema(_ context.Context, _ resource.SchemaReque
 					},
 					"text_alignment": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The alignment of the text in the email body",
 						Validators: []validator.String{
 							stringvalidator.OneOf(toStrings(emailtemplates.TextAlignments())...),
@@ -456,14 +466,17 @@ func (r *emailTemplateResource) Schema(_ context.Context, _ resource.SchemaReque
 					},
 					"html_content": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The HTML content of the email body",
 					},
 					"plaintext_content": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The plaintext content of the email body",
 					},
 					"subject": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The subject line in the email template",
 					},
 				},

--- a/internal/provider/resources/emailtemplate_test.go
+++ b/internal/provider/resources/emailtemplate_test.go
@@ -122,6 +122,42 @@ func TestAccEmailTemplateResource(t *testing.T) {
 			},
 			shouldSkip: customDomain == "",
 		},
+		{
+			TestCase: testutil.TestCase{
+				Name: "custom-without-plaintext",
+				Config: testutil.ConsumerProjectConfig + `
+      resource "stytch_email_template" "test" {
+        live_project_id = stytch_project.project.live_project_id
+        template_id = "tf-test-custom-2"
+        name = "tf-test-custom-2"
+        sender_information = {
+          from_local_part = "noreply"
+          from_domain = "` + customDomain + `"
+          from_name = "Stytch"
+          reply_to_local_part = "support"
+          reply_to_name = "Support"
+        }
+        custom_html_customization = {
+          template_type = "LOGIN"
+          html_content = "<h1>Login now: {{magic_link_url}}</h1>"
+          subject = "Login to ` + customDomain + `"
+        }
+      }`,
+				Checks: []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-custom"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-custom"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_local_part", "noreply"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_domain", customDomain),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_name", "Stytch"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_local_part", "support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_name", "Support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.template_type", "LOGIN"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.html_content", "<h1>Login now: {{magic_link_url}}</h1>"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.subject", "Login to "+customDomain),
+				},
+			},
+			shouldSkip: customDomain == "",
+		},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
 			if testCase.shouldSkip {

--- a/internal/provider/resources/emailtemplate_test.go
+++ b/internal/provider/resources/emailtemplate_test.go
@@ -144,8 +144,8 @@ func TestAccEmailTemplateResource(t *testing.T) {
         }
       }`,
 				Checks: []resource.TestCheckFunc{
-					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-custom"),
-					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-custom"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-custom-2"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-custom-2"),
 					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_local_part", "noreply"),
 					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_domain", customDomain),
 					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_name", "Stytch"),

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "0.1.1"
+const Version = "0.1.2"


### PR DESCRIPTION
A number of these fields should have been marked as computed. You can specify a _subset_ of the schema within prebuilt/custom without specifying _every_ field. This fixes that issue.

# Testing
Added new acceptance test where html_content is provided without associated plaintext_content.

`make testacc`

All pass.