### PR TITLE
[BACK-4673] Update Terraform documentation to specify required parameters for custom email templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,16 @@ test:
 
 .PHONY: testacc
 testacc:
-	TF_ACC=1 $(TEST_CMD) ./...
+	TF_ACC=1 $(TEST_CMD) ./internal/provider/resources/emailtemplate_test.go # ./...
 
 .PHONY: toggle-local-management-go
 toggle-local-management-go:
 	./hack/toggle-dependency.sh stytch-management-go
+
+# Initial setup:
+# export STYTCH_WORKSPACE_KEY_ID=workspace-key-prod-1c7c5264-5e94-493b-9931-7a85e5e0f52d
+# export STYTCH_WORKSPACE_KEY_SECRET=-QN1FMMVVqELfPcAKjrVWfiGqDuijQ5UU5lhpeF_LU29KbhY
+
+# Failed to create email template w/ "invalid_workspace_domain", "Not found":
+# export STYTCH_CUSTOM_DOMAIN=logangore.dev
+

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test:
 
 .PHONY: testacc
 testacc:
-	TF_ACC=1 $(TEST_CMD) ./internal/provider/resources/emailtemplate_test.go # ./...
+	TF_ACC=1 $(TEST_CMD) ./...
 
 .PHONY: toggle-local-management-go
 toggle-local-management-go:

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,3 @@ testacc:
 .PHONY: toggle-local-management-go
 toggle-local-management-go:
 	./hack/toggle-dependency.sh stytch-management-go
-
-# Initial setup:
-# export STYTCH_WORKSPACE_KEY_ID=workspace-key-prod-1c7c5264-5e94-493b-9931-7a85e5e0f52d
-# export STYTCH_WORKSPACE_KEY_SECRET=-QN1FMMVVqELfPcAKjrVWfiGqDuijQ5UU5lhpeF_LU29KbhY
-
-# Failed to create email template w/ "invalid_workspace_domain", "Not found":
-# export STYTCH_CUSTOM_DOMAIN=logangore.dev
-

--- a/internal/provider/resources/emailtemplate.go
+++ b/internal/provider/resources/emailtemplate.go
@@ -458,8 +458,14 @@ func (r *emailTemplateResource) Schema(_ context.Context, _ resource.SchemaReque
 				Description: "Customization defined for completely custom HTML email templates",
 				Attributes: map[string]schema.Attribute{
 					"template_type": schema.StringAttribute{
-						Optional:    true,
-						Description: "The type of email template this custom HTML customization is valid for",
+						Optional: true,
+						Description: "The type of email template this custom HTML customization " +
+							"is valid for. Each template type will require different parameters " +
+							"to be set in html_content and plaintext_content. LOGIN, SIGNUP, " +
+							"and INVITE require the magic_link_url parameter; ONE_TIME_PASSCODE " +
+							"and ONE_TIME_PASSCODE_SIGNUP require the otp_code parameter; " +
+							"RESET_PASSWORD and VERIFY_EMAIL_PASSWORD_RESET require the " +
+							"reset_password_url parameter.",
 						Validators: []validator.String{
 							stringvalidator.OneOf(toStrings(emailtemplates.TemplateTypes())...),
 						},

--- a/internal/provider/resources/emailtemplate_test.go
+++ b/internal/provider/resources/emailtemplate_test.go
@@ -86,12 +86,12 @@ func TestAccEmailTemplateResource(t *testing.T) {
 		},
 		{
 			TestCase: testutil.TestCase{
-				Name: "custom",
+				Name: "custom login",
 				Config: testutil.ConsumerProjectConfig + `
       resource "stytch_email_template" "test" {
         live_project_id = stytch_project.project.live_project_id
-        template_id = "tf-test-custom"
-        name = "tf-test-custom"
+        template_id = "tf-test-custom-login"
+        name = "tf-test-custom-login"
         sender_information = {
           from_local_part = "noreply"
           from_domain = "` + customDomain + `"
@@ -107,8 +107,8 @@ func TestAccEmailTemplateResource(t *testing.T) {
         }
       }`,
 				Checks: []resource.TestCheckFunc{
-					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-custom"),
-					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-custom"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-custom-login"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-custom-login"),
 					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_local_part", "noreply"),
 					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_domain", customDomain),
 					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_name", "Stytch"),
@@ -118,6 +118,82 @@ func TestAccEmailTemplateResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.html_content", "<h1>Login now: {{magic_link_url}}</h1>"),
 					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.plaintext_content", "Plaintext login now: {{magic_link_url}}"),
 					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.subject", "Login to "+customDomain),
+				},
+			},
+			shouldSkip: customDomain == "",
+		},
+		{
+			TestCase: testutil.TestCase{
+				Name: "custom reset password",
+				Config: testutil.ConsumerProjectConfig + `
+      resource "stytch_email_template" "test" {
+        live_project_id = stytch_project.project.live_project_id
+        template_id = "tf-test-custom-reset-password"
+        name = "tf-test-custom-reset-password"
+        sender_information = {
+          from_local_part = "noreply"
+          from_domain = "` + customDomain + `"
+          from_name = "Stytch"
+          reply_to_local_part = "support"
+          reply_to_name = "Support"
+        }
+        custom_html_customization = {
+          template_type = "RESET_PASSWORD"
+          html_content = "<h1>Reset password now: {{reset_password_url}}</h1>"
+          plaintext_content = "Plaintext reset password now: {{reset_password_url}}"
+          subject = "Reset password for ` + customDomain + `"
+        }
+      }`,
+				Checks: []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-custom-reset-password"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-custom-reset-password"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_local_part", "noreply"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_domain", customDomain),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_name", "Stytch"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_local_part", "support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_name", "Support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.template_type", "RESET_PASSWORD"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.html_content", "<h1>Reset password now: {{reset_password_url}}</h1>"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.plaintext_content", "Plaintext reset password now: {{reset_password_url}}"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.subject", "Reset password for "+customDomain),
+				},
+			},
+			shouldSkip: customDomain == "",
+		},
+		{
+			TestCase: testutil.TestCase{
+				Name: "custom otp",
+				Config: testutil.ConsumerProjectConfig + `
+      resource "stytch_email_template" "test" {
+        live_project_id = stytch_project.project.live_project_id
+        template_id = "tf-test-custom-otp"
+        name = "tf-test-custom-otp"
+        sender_information = {
+          from_local_part = "noreply"
+          from_domain = "` + customDomain + `"
+          from_name = "Stytch"
+          reply_to_local_part = "support"
+          reply_to_name = "Support"
+        }
+        custom_html_customization = {
+          template_type = "ONE_TIME_PASSCODE"
+          html_content = "<h1>One time passcode: {{otp_code}}</h1>"
+          plaintext_content = "Plaintext one time passcode: {{otp_code}}"
+          subject = "OTP for ` + customDomain + `"
+        }
+      }`,
+				Checks: []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr("stytch_email_template.test", "template_id", "tf-test-custom-otp"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "name", "tf-test-custom-otp"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_local_part", "noreply"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_domain", customDomain),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.from_name", "Stytch"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_local_part", "support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "sender_information.reply_to_name", "Support"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.template_type", "ONE_TIME_PASSCODE"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.html_content", "<h1>One time passcode: {{otp_code}}</h1>"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.plaintext_content", "Plaintext one time passcode: {{otp_code}}"),
+					resource.TestCheckResourceAttr("stytch_email_template.test", "custom_html_customization.subject", "OTP for "+customDomain),
 				},
 			},
 			shouldSkip: customDomain == "",

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "1.1.1"
+const Version = "1.1.2"

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,7 @@
 module tools
 
-go 1.22.7
+go 1.23.0
+
 toolchain go1.24.1
 
 require github.com/hashicorp/terraform-plugin-docs v0.19.4


### PR DESCRIPTION
Part of BACK-4673.

Also added new acceptance tests for documentation through code.