### PR TITLE
Add semgrep for missing returns after AddError

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,16 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.24
           cache: true
 
       - uses: golangci/golangci-lint-action@v6.1.1
         with:
-          version: v1.61
+          version: v2.1.6
           args: --timeout 5m
+
+      - name: Semgrep
+        run: make semgrep-ci
 
   test:
     runs-on: ubuntu-latest
@@ -30,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.24
           cache: true
 
       - run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - semgrep-rules/*
 issues:
   max-same-issues: 0
 formatters:
@@ -39,3 +40,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - semgrep-rules/*

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,20 @@
+# Ignore git items
+.gitignore
+.git/
+:include .gitignore
+
+# Common large paths
+node_modules/
+build/
+dist/
+vendor/
+.env/
+.venv/
+.tox/
+*.min.js
+
+# Semgrep rules folder
+semgrep-rules/
+
+# Semgrep-action log folder
+.semgrep_logs/

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,22 @@ build:
 install: build
 	go install -v ./...
 
+# Prefer local semgrep to the dockerized version. The container image is the same one used by CI.
+ifneq (,$(shell which semgrep))
+SEMGREP := semgrep
+else
+SEMGREP := docker run -v "$$(pwd)":/src --workdir /src semgrep/semgrep:1.61.1 semgrep
+endif
+
+.PHONY: semgrep
+semgrep:
+	${SEMGREP} --config semgrep-rules --metrics=off
+	$(MAKE) fmt lint
+
+.PHONY: semgrep-ci
+semgrep-ci:
+	${SEMGREP} ci --config semgrep-rules --metrics=off
+
 .PHONY: lint
 lint:
 	golangci-lint run

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stytchauth/terraform-provider-stytch
 
-go 1.22.7
+go 1.24.2
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.13.0

--- a/internal/provider/resources/consumersdkconfig.go
+++ b/internal/provider/resources/consumersdkconfig.go
@@ -1141,6 +1141,7 @@ func (r *consumerSDKConfigResource) Read(ctx context.Context, req resource.ReadR
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get Consumer SDK config", err.Error())
+		return
 	}
 
 	tflog.Info(ctx, "Read Consumer SDK config")

--- a/internal/provider/resources/publictoken.go
+++ b/internal/provider/resources/publictoken.go
@@ -144,6 +144,7 @@ func (r *publicTokenResource) Read(ctx context.Context, req resource.ReadRequest
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get public token", err.Error())
+		return
 	}
 
 	found := false
@@ -172,6 +173,7 @@ func (r *publicTokenResource) Read(ctx context.Context, req resource.ReadRequest
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *publicTokenResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	resp.Diagnostics.AddError("Update not allowed", "Updating this resource is not supported. Please delete and recreate the resource.")
+	return //nolint:staticcheck // needed so Semgrep rule can enforce AddError followed by return
 }
 
 // Delete deletes the resource and removes the Terraform state on success.

--- a/internal/provider/resources/secret.go
+++ b/internal/provider/resources/secret.go
@@ -171,6 +171,7 @@ func (r *secretResource) Read(ctx context.Context, req resource.ReadRequest, res
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *secretResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	resp.Diagnostics.AddError("Update not allowed", "Updating this resource is not supported. Please delete and recreate the resource.")
+	return //nolint:staticcheck // needed so Semgrep rule can enforce AddError followed by return
 }
 
 // Delete deletes the resource and removes the Terraform state on success.

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "1.2.2"
+const Version = "1.2.3"

--- a/semgrep-rules/adderror-must-be-followed-by-return.go
+++ b/semgrep-rules/adderror-must-be-followed-by-return.go
@@ -1,0 +1,81 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+type Resp struct {
+	Diagnostics diag.Diagnostics
+}
+
+func testAddErrorWithImmediateReturn(resp Resp, req any) {
+	// ok: adderror-must-be-followed-by-return
+	resp.Diagnostics.AddError(
+		"Unexpected Data Source Configure Type",
+		fmt.Sprintf("Expected *api.API, got: %T", req),
+	)
+	return
+}
+
+func testAddErrorWithImmediateReturnAfterBlankLine(resp Resp, req any) {
+	// ok: adderror-must-be-followed-by-return
+	resp.Diagnostics.AddError(
+		"Unexpected Data Source Configure Type",
+		fmt.Sprintf("Expected *api.API, got: %T", req),
+	)
+
+	return
+}
+
+func testAddErrorWithoutReturn(resp Resp, req any) {
+	// ruleid: adderror-must-be-followed-by-return
+	resp.Diagnostics.AddError(
+		"Unexpected Data Source Configure Type",
+		fmt.Sprintf("Expected *api.API, got: %T", req),
+	)
+
+	fmt.Println("error added")
+	return
+}
+
+func testAddErrorWithReturnInline(resp Resp, req any) {
+	if true {
+		// ok: adderror-must-be-followed-by-return
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type", fmt.Sprintf("Expected *api.API, got: %T", req))
+		return
+	}
+}
+
+func testAddErrorNoReturnAtAll(resp Resp, req any) {
+	if true {
+		// ruleid: adderror-must-be-followed-by-return
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type", fmt.Sprintf("Expected *api.API, got: %T", req))
+		fmt.Println("not returning")
+	}
+}
+
+func testAddErrorNotFollowedByReturnInline(resp Resp, req any) {
+	if true {
+		// ruleid: adderror-must-be-followed-by-return
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *api.API, got: %T", req),
+		)
+		fmt.Println("returning!")
+		return
+	}
+}
+
+func ValidateConfig(resp Resp, req any) {
+	// ok: adderror-must-be-followed-by-return
+	resp.Diagnostics.AddError(
+		"Unexpected Data Source Configure Type",
+		fmt.Sprintf("Expected *api.API, got: %T", req),
+	)
+	resp.Diagnostics.AddError(
+		"Something else",
+		"Oh no!",
+	)
+}

--- a/semgrep-rules/adderror-must-be-followed-by-return.yml
+++ b/semgrep-rules/adderror-must-be-followed-by-return.yml
@@ -1,0 +1,19 @@
+rules:
+  - id: adderror-must-be-followed-by-return
+    languages: [go]
+    severity: ERROR
+    message: "`AddError` must be immediately followed by a `return` statement."
+    metadata:
+      category: correctness
+    patterns:
+      - pattern: $RESP.Diagnostics.AddError($TITLE, $MSG)
+      - pattern-not-inside: |
+          $RESP.Diagnostics.AddError($TITLE, $MSG)
+          return
+      - pattern-not-inside: |
+          func ValidateConfig(...) {
+            ...
+          }
+    fix: |
+      $RESP.Diagnostics.AddError($TITLE, $MSG)
+      return


### PR DESCRIPTION
Proactively identifies cases where an early `return` was missed.