### PR TITLE
[BACK-4792] Fix type for redirecturl validTypes attribute

### DIFF
--- a/internal/provider/resources/redirecturl.go
+++ b/internal/provider/resources/redirecturl.go
@@ -149,9 +149,16 @@ func (m redirectURLModel) toValidTypes() []redirecturls.URLRedirectType {
 	for _, elem := range m.ValidTypes.Elements() {
 		if obj, ok := elem.(types.Object); ok {
 			attrs := obj.Attributes()
+
+			typeAttr, isTypeStr := attrs["type"].(types.String)
+			isDefaultAttr, isDefaultBool := attrs["is_default"].(types.Bool)
+			if !isTypeStr || !isDefaultBool {
+				continue
+			}
+
 			validTypes = append(validTypes, redirecturls.URLRedirectType{
-				Type:      redirecturls.RedirectType(attrs["type"].(types.String).ValueString()),
-				IsDefault: attrs["is_default"].(types.Bool).ValueBool(),
+				Type:      redirecturls.RedirectType(typeAttr.ValueString()),
+				IsDefault: isDefaultAttr.ValueBool(),
 			})
 		}
 	}

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "1.5.0"
+const Version = "1.5.1"


### PR DESCRIPTION
## Description

Fixes https://github.com/stytchauth/terraform-provider-stytch/issues/77

## Tests

The sdk testing framework unfortunately does not allow me to test `for_each`, but I tested manually

main.tf:

```
locals {
  redirect_urls = [
    { url = "http://localhost:3000/consumer", valid_types = [
      { type = "LOGIN", is_default = true },
      { type = "SIGNUP", is_default = false },
      { type = "RESET_PASSWORD", is_default = false },
    ] },
  ]
}

resource "stytch_project" "test_project" {
  name     = "test for_each"
  vertical = "CONSUMER"
}

resource "stytch_redirect_url" "test" {
  for_each    = { for url in local.redirect_urls : url.url => url }
  project_id  = stytch_project.test_project.test_project_id
  url         = each.value.url
  valid_types = each.value.valid_types
}
```

`terraform plan` output

```
Terraform will perform the following actions:

  # stytch_project.test_project will be created
  + resource "stytch_project" "test_project" {
      + created_at                        = (known after apply)
      + id                                = (known after apply)
      + last_updated                      = (known after apply)
      + live_cross_org_passwords_enabled  = (known after apply)
      + live_oauth_callback_id            = (known after apply)
      + live_project_id                   = (known after apply)
      + live_user_impersonation_enabled   = (known after apply)
      + live_user_lock_self_serve_enabled = (known after apply)
      + live_user_lock_threshold          = (known after apply)
      + live_user_lock_ttl                = (known after apply)
      + name                              = "test for_each"
      + test_cross_org_passwords_enabled  = (known after apply)
      + test_oauth_callback_id            = (known after apply)
      + test_project_id                   = (known after apply)
      + test_user_impersonation_enabled   = (known after apply)
      + test_user_lock_self_serve_enabled = (known after apply)
      + test_user_lock_threshold          = (known after apply)
      + test_user_lock_ttl                = (known after apply)
      + vertical                          = "CONSUMER"
    }

  # stytch_redirect_url.test["http://localhost:3000/consumer"] will be created
  + resource "stytch_redirect_url" "test" {
      + last_updated = (known after apply)
      + project_id   = (known after apply)
      + url          = "http://localhost:3000/consumer"
      + valid_types  = [
          + {
              + is_default = false
              + type       = "RESET_PASSWORD"
            },
          + {
              + is_default = false
              + type       = "SIGNUP"
            },
          + {
              + is_default = true
              + type       = "LOGIN"
            },
        ]
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```