### PR TITLE
Fix nil client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ website/vendor
 # Ignore env files
 .env
 .envrc
+
+# ignore go vendor
+vendor/

--- a/internal/provider/resources/rbacpolicy.go
+++ b/internal/provider/resources/rbacpolicy.go
@@ -408,9 +408,9 @@ func (r rbacPolicyResource) ValidateConfig(ctx context.Context, req resource.Val
 		return
 	}
 
-	// If the projectID isn't yet known, skip validation for now.
+	// If the projectID isn't yet known or the provider client is not injected, skip validation for now.
 	// The plugin framework will call ValidateConfig again when all required values are known.
-	if data.ProjectID.IsUnknown() {
+	if data.ProjectID.IsUnknown() || r.client == nil {
 		return
 	}
 


### PR DESCRIPTION
## Issue

```bash
╷
│ Error: Request cancelled
│ 
│ The plugin6.(*GRPCProvider).ValidateResourceConfig request was cancelled.
╵

Stack trace from the terraform-provider-stytch_v1.5.1 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xb33bb1]

goroutine 22 [running]:
github.com/stytchauth/terraform-provider-stytch/internal/provider/resources.rbacPolicyResource.ValidateConfig({0x0?}, {0xefa498, 0xc00030d770}, {{{{0xeff650, 0xc000273260}, {0xc9c0e0, 0xc0006a8d80}}, {0xf01278, 0xc000502050}}, {0x1}}, ...)
...
...
Error: The terraform-provider-stytch_v1.5.1 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

## Test

I have tested this by overriding my local terraform-provider