### PR TITLE
[DNM] Example of how *not* to fix #83

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,6 +7,9 @@ Thanks for contributing to Stytch's Terraform Provider plugin! If you run into t
 ### Prerequisites
 
 - [Terraform](https://www.terraform.io/)
+
+* [Go](https://go.dev/doc/install) (version 1.24 or later)
+
 - A [Stytch](https://stytch.com) workspace
 - A [workspace management key + secret](https://stytch.com/dashboard/settings/management-api) for your Stytch workspace
   - Create a new key and store the key + secret somewhere safe
@@ -22,6 +25,31 @@ export STYTCH_WORKSPACE_KEY_SECRET=my_secret_goes_here
 
 The `stytch` provider will attempt to read environment variables for configuring the client.
 You can also set these directly in the provider configuration, but it is not recommended.
+
+### Pointing terraform to your local provider
+
+First get the location of your go bin:
+
+```sh
+echo "${GOBIN:-$(go env GOPATH)/bin}"
+```
+
+Add the following to your `~/.terraformrc` file to point Terraform to your local provider build:
+
+```hcl
+provider_installation {
+
+  dev_overrides {
+      # "registry.terraform.io/stytchauth/stytch" = "INSERT_GOBIN_PATH_HERE"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
+
+```
 
 ## Issues and Pull Requests
 

--- a/internal/provider/resources/rbacpolicy_test.go
+++ b/internal/provider/resources/rbacpolicy_test.go
@@ -81,6 +81,38 @@ func TestAccRBACPolicyResource(t *testing.T) {
 				}),
 			},
 		},
+		{
+			Name: "admin-resource",
+			Config: testutil.B2BProjectConfig + `
+			resource "stytch_rbac_policy" "test" {
+				project_id = stytch_project.project.test_project_id
+				stytch_admin = {
+					permissions = [
+						{
+							resource_id = "custom_resource_1"
+							actions     = ["read"]
+						}
+					]
+				}
+
+				custom_resources = [
+					{
+						resource_id       = "custom_resource_1"
+						description       = "A custom resource for testing."
+						available_actions = ["read", "write"]
+					}
+				]
+			}
+			`,
+			Checks: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr("stytch_rbac_policy.test", "custom_resources.#", "1"),
+				resource.TestCheckTypeSetElemNestedAttrs("stytch_rbac_policy.test", "stytch_admin.*", map[string]string{
+					"role_id":       "my-custom-admin",
+					"description":   "My custom admin role",
+					"permissions.#": "2",
+				}),
+			},
+		},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
 			resource.Test(t, resource.TestCase{


### PR DESCRIPTION
This is an example of how *not* to fix #83, left here for posterity. #84 is the best fix available for now.

The reason this doesn't work is that we *allow* a provisioner to remove our default permissions from the stytch_member and stytch_admin roles, but then if you try to delete the resource, it's not clear how we should restore those default permissions (and we don't allow a role to contain zero permissions).