### PR TITLE
Don't treat custom resources as default

### DIFF
--- a/internal/provider/resources/rbacpolicy.go
+++ b/internal/provider/resources/rbacpolicy.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -193,6 +194,12 @@ func (m rbacPolicyRoleModel) toRole() rbacpolicy.Role {
 func (m rbacPolicyRoleModel) enforceDefaultPermissions(defaultPerms []rbacpolicy.Permission) diag.Diagnostics {
 	var diags diag.Diagnostics
 	for _, perm := range defaultPerms {
+		if !strings.HasPrefix(perm.ResourceID, "stytch.") {
+			// Only enforce default permissions for Stytch-created resources
+			// TODO: We could be better about detecting this and instead enumerate the stytch_resources
+			continue
+		}
+
 		found := false
 		for _, p := range m.Permissions {
 			if p.ResourceID.ValueString() == perm.ResourceID {

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "1.5.3"
+const Version = "1.5.4"


### PR DESCRIPTION
This isn't perfect, but it addresses a bug report from today. We should only count resources as "default" if they begin with `stytch.`