### PR TITLE
Deprecate unused SDK configs

### DIFF
--- a/docs/resources/b2b_sdk_config.md
+++ b/docs/resources/b2b_sdk_config.md
@@ -19,7 +19,6 @@ resource "stytch_b2b_sdk_config" "b2b_sdk_config" {
   config = {
     basic = {
       enabled                   = true
-      create_new_members        = true
       allow_self_onboarding     = true
       enable_member_permissions = true
       domains                   = []
@@ -33,9 +32,8 @@ resource "stytch_b2b_sdk_config" "b2b_sdk_config" {
       create_totps = true
     }
     dfppa = {
-      enabled                = "ENABLED"
-      on_challenge           = "TRIGGER_CAPTCHA"
-      lookup_timeout_seconds = 3
+      enabled      = "ENABLED"
+      on_challenge = "TRIGGER_CAPTCHA"
     }
     cookies = {
       http_only = "DISABLED"
@@ -87,7 +85,7 @@ Optional:
 
 - `allow_self_onboarding` (Boolean) A boolean indicating whether self-onboarding is allowed for members in the SDK.
 - `bundle_ids` (Set of String) A list of bundle IDs authorized for use in the SDK.
-- `create_new_members` (Boolean) A boolean indicating whether new members can be created with the SDK.
+- `create_new_members` (Boolean, Deprecated) A boolean indicating whether new members can be created with the SDK.
 - `domains` (Attributes Set) A list of domains authorized for use in the SDK. (see [below for nested schema](#nestedatt--config--basic--domains))
 - `enable_member_permissions` (Boolean) A boolean indicating whether member permissions RBAC are enabled in the SDK.
 
@@ -115,7 +113,7 @@ Optional:
 Optional:
 
 - `enabled` (String) A boolean indicating whether Device Fingerprinting Protected Auth is enabled in the SDK.
-- `lookup_timeout_seconds` (Number) How long to wait for a DFPPA lookup to complete before timing out.
+- `lookup_timeout_seconds` (Number, Deprecated) How long to wait for a DFPPA lookup to complete before timing out.
 - `on_challenge` (String) The action to take when a DFPPA 'challenge' verdict is returned.
 
 

--- a/docs/resources/consumer_sdk_config.md
+++ b/docs/resources/consumer_sdk_config.md
@@ -18,10 +18,9 @@ resource "stytch_consumer_sdk_config" "consumer_sdk_config" {
   project_id = stytch_project.consumer_project.test_project_id
   config = {
     basic = {
-      enabled          = true
-      create_new_users = true
-      domains          = []
-      bundle_ids       = []
+      enabled    = true
+      domains    = []
+      bundle_ids = []
     }
     sessions = {
       max_session_duration_minutes = 60
@@ -82,7 +81,7 @@ Required:
 Optional:
 
 - `bundle_ids` (Set of String) A list of bundle IDs authorized for use in the SDK.
-- `create_new_users` (Boolean) A boolean indicating whether new users can be created with the SDK.
+- `create_new_users` (Boolean, Deprecated) A boolean indicating whether new users can be created with the SDK.
 - `domains` (Set of String) A list of domains authorized for use in the SDK.
 
 
@@ -118,7 +117,7 @@ Optional:
 Optional:
 
 - `enabled` (String) A boolean indicating whether Device Fingerprinting Protected Auth is enabled in the SDK.
-- `lookup_timeout_seconds` (Number) How long to wait for a DFPPA lookup to complete before timing out.
+- `lookup_timeout_seconds` (Number, Deprecated) How long to wait for a DFPPA lookup to complete before timing out.
 - `on_challenge` (String) The action to take when a DFPPA 'challenge' verdict is returned.
 
 

--- a/examples/resources/stytch_b2b_sdk_config/resource.tf
+++ b/examples/resources/stytch_b2b_sdk_config/resource.tf
@@ -4,7 +4,6 @@ resource "stytch_b2b_sdk_config" "b2b_sdk_config" {
   config = {
     basic = {
       enabled                   = true
-      create_new_members        = true
       allow_self_onboarding     = true
       enable_member_permissions = true
       domains                   = []
@@ -18,9 +17,8 @@ resource "stytch_b2b_sdk_config" "b2b_sdk_config" {
       create_totps = true
     }
     dfppa = {
-      enabled                = "ENABLED"
-      on_challenge           = "TRIGGER_CAPTCHA"
-      lookup_timeout_seconds = 3
+      enabled      = "ENABLED"
+      on_challenge = "TRIGGER_CAPTCHA"
     }
     cookies = {
       http_only = "DISABLED"

--- a/examples/resources/stytch_consumer_sdk_config/resource.tf
+++ b/examples/resources/stytch_consumer_sdk_config/resource.tf
@@ -3,10 +3,9 @@ resource "stytch_consumer_sdk_config" "consumer_sdk_config" {
   project_id = stytch_project.consumer_project.test_project_id
   config = {
     basic = {
-      enabled          = true
-      create_new_users = true
-      domains          = []
-      bundle_ids       = []
+      enabled    = true
+      domains    = []
+      bundle_ids = []
     }
     sessions = {
       max_session_duration_minutes = 60

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/stytchauth/stytch-management-go/v2 v2.5.1
+	github.com/stytchauth/stytch-management-go/v2 v2.7.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stytchauth/stytch-management-go/v2 v2.5.1 h1:EpKhI8ldClQ3qzTN7pjSEWzo5D5CT/o3dSwQr3+jYk4=
-github.com/stytchauth/stytch-management-go/v2 v2.5.1/go.mod h1:ZxdmhZGDzOXFaj0rHT4TmJk4CPRV+WC+bRZlB08oHcs=
+github.com/stytchauth/stytch-management-go/v2 v2.7.0 h1:+QnaIDh5mynKOyAt+KFEALMOA0ph8+QQloRIKff7T4I=
+github.com/stytchauth/stytch-management-go/v2 v2.7.0/go.mod h1:ZxdmhZGDzOXFaj0rHT4TmJk4CPRV+WC+bRZlB08oHcs=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resources/b2bsdkconfig.go
+++ b/internal/provider/resources/b2bsdkconfig.go
@@ -584,9 +584,10 @@ func (r *b2bSDKConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 								Description: "A boolean indicating whether the B2B project SDK is enabled. This allows the SDK to manage user and session data.",
 							},
 							"create_new_members": schema.BoolAttribute{
-								Optional:    true,
-								Computed:    true,
-								Description: "A boolean indicating whether new members can be created with the SDK.",
+								Optional:           true,
+								Computed:           true,
+								Description:        "A boolean indicating whether new members can be created with the SDK.",
+								DeprecationMessage: "This field is deprecated and no longer affects SDK functionality. It will be removed in a future major release.",
 								PlanModifiers: []planmodifier.Bool{
 									boolplanmodifier.UseStateForUnknown(),
 								},
@@ -866,9 +867,10 @@ func (r *b2bSDKConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 								},
 							},
 							"lookup_timeout_seconds": schema.Int32Attribute{
-								Optional:    true,
-								Computed:    true,
-								Description: "How long to wait for a DFPPA lookup to complete before timing out.",
+								Optional:           true,
+								Computed:           true,
+								Description:        "How long to wait for a DFPPA lookup to complete before timing out.",
+								DeprecationMessage: "This field is deprecated and no longer affects SDK functionality. It will be removed in a future major release.",
 								PlanModifiers: []planmodifier.Int32{
 									int32planmodifier.UseStateForUnknown(),
 								},

--- a/internal/provider/resources/consumersdkconfig.go
+++ b/internal/provider/resources/consumersdkconfig.go
@@ -647,9 +647,10 @@ func (r *consumerSDKConfigResource) Schema(_ context.Context, _ resource.SchemaR
 								Description: "A boolean indicating whether the consumer project SDK is enabled. This allows the SDK to manage user and session data.",
 							},
 							"create_new_users": schema.BoolAttribute{
-								Optional:    true,
-								Computed:    true,
-								Description: "A boolean indicating whether new users can be created with the SDK.",
+								Optional:           true,
+								Computed:           true,
+								Description:        "A boolean indicating whether new users can be created with the SDK.",
+								DeprecationMessage: "This field is deprecated and no longer affects SDK functionality. It will be removed in a future major release.",
 								PlanModifiers: []planmodifier.Bool{
 									boolplanmodifier.UseStateForUnknown(),
 								},
@@ -959,9 +960,10 @@ func (r *consumerSDKConfigResource) Schema(_ context.Context, _ resource.SchemaR
 								},
 							},
 							"lookup_timeout_seconds": schema.Int32Attribute{
-								Optional:    true,
-								Computed:    true,
-								Description: "How long to wait for a DFPPA lookup to complete before timing out.",
+								Optional:           true,
+								Computed:           true,
+								Description:        "How long to wait for a DFPPA lookup to complete before timing out.",
+								DeprecationMessage: "This field is deprecated and no longer affects SDK functionality. It will be removed in a future major release.",
 								PlanModifiers: []planmodifier.Int32{
 									int32planmodifier.UseStateForUnknown(),
 								},

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "1.5.4"
+const Version = "1.6.0"


### PR DESCRIPTION
## Description

Marks 4 attributes deprecated, since they no longer affect SDK functionality. These will be removed in the future. Part of [ONCALL-1070](https://linear.app/stytch/issue/ONCALL-1070)

## Tests

PR tests