### PR TITLE
Fix other redirect URL routes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/stytchauth/stytch-management-go/v2 v2.7.1
+	github.com/stytchauth/stytch-management-go/v2 v2.7.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stytchauth/stytch-management-go/v2 v2.7.1 h1:TxYAvKU0RoevHcu08JmChrJz8a2kFZSu4UuGeNrcjm4=
-github.com/stytchauth/stytch-management-go/v2 v2.7.1/go.mod h1:ZxdmhZGDzOXFaj0rHT4TmJk4CPRV+WC+bRZlB08oHcs=
+github.com/stytchauth/stytch-management-go/v2 v2.7.2 h1:8HTM3jABdJFmqROCRwLM8EFgIdRrseSAyMxonF/r/Ak=
+github.com/stytchauth/stytch-management-go/v2 v2.7.2/go.mod h1:ZxdmhZGDzOXFaj0rHT4TmJk4CPRV+WC+bRZlB08oHcs=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "1.6.1"
+const Version = "1.6.2"


### PR DESCRIPTION
Bumps stytch-management-go which just landed a fix for UPDATE and DELETE redirect URL routes