### PR TITLE
[V3] Set password config boolean defaults to true

### DIFF
--- a/internal/provider/resources/password_config.go
+++ b/internal/provider/resources/password_config.go
@@ -107,19 +107,19 @@ func (r *passwordConfigResource) Schema(
 			"check_breach_on_creation": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
-				Default:     booldefault.StaticBool(false),
+				Default:     booldefault.StaticBool(true),
 				Description: "Whether to use the HaveIBeenPwned database to detect password breaches when a user first creates their password.",
 			},
 			"check_breach_on_authentication": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
-				Default:     booldefault.StaticBool(false),
+				Default:     booldefault.StaticBool(true),
 				Description: "Whether to use the HaveIBeenPwned database to detect password breaches when a user authenticates.",
 			},
 			"validate_on_authentication": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
-				Default:     booldefault.StaticBool(false),
+				Default:     booldefault.StaticBool(true),
 				Description: "Whether to require a password reset on authentication if a user's current password no longer meets the environment's current policy requirements.",
 			},
 			"validation_policy": schema.StringAttribute{

--- a/internal/provider/resources/password_config_test.go
+++ b/internal/provider/resources/password_config_test.go
@@ -19,16 +19,16 @@ func TestAccPasswordConfigResource(t *testing.T) {
       resource "stytch_password_config" "test" {
         project_slug                     = stytch_project.test.project_slug
         environment_slug                 = stytch_environment.test.environment_slug
-        check_breach_on_creation         = true
-        check_breach_on_authentication   = true
-        validate_on_authentication       = false
+        check_breach_on_authentication   = false
         validation_policy                = "ZXCVBN"
       }`,
 			Checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttrSet("stytch_password_config.test", "id"),
+				// Confirms that default value is set correctly
 				resource.TestCheckResourceAttr("stytch_password_config.test", "check_breach_on_creation", "true"),
-				resource.TestCheckResourceAttr("stytch_password_config.test", "check_breach_on_authentication", "true"),
-				resource.TestCheckResourceAttr("stytch_password_config.test", "validate_on_authentication", "false"),
+				resource.TestCheckResourceAttr("stytch_password_config.test", "check_breach_on_authentication", "false"),
+				// Confirms that default value is set correctly
+				resource.TestCheckResourceAttr("stytch_password_config.test", "validate_on_authentication", "true"),
 				resource.TestCheckResourceAttr("stytch_password_config.test", "validation_policy", "ZXCVBN"),
 			},
 		},


### PR DESCRIPTION
## Description

Sets the boolean attributes in password config to true. This matches the default settings for new Stytch environments, and is the recommended behavior by Stytch.

## Testing

Modified test and it passes