### PR TITLE
Updates for codegen'd v3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ linters:
     - durationcheck
     - errcheck
     - forcetypeassert
-    - godot
     - govet
     - ineffassign
     - makezero

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/stytchauth/stytch-management-go/v3 v3.0.0-alpha.4
+	github.com/stytchauth/stytch-management-go/v3 v3.0.0-alpha.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stytchauth/stytch-management-go/v3 v3.0.0-alpha.4 h1:WI9lbZuVhIgnwVRrNX9KpO5cUpHaZy1WGZdGKlRlRf8=
-github.com/stytchauth/stytch-management-go/v3 v3.0.0-alpha.4/go.mod h1:k+FmnJeRGHSieasyPhrMDZiLQn2l8o/HiZVyCBKsznU=
+github.com/stytchauth/stytch-management-go/v3 v3.0.0-alpha.5 h1:nSf/6vsEu1GZ0E6ZQBfD/IHfCRRWts8PRmR9mafj3YQ=
+github.com/stytchauth/stytch-management-go/v3 v3.0.0-alpha.5/go.mod h1:k+FmnJeRGHSieasyPhrMDZiLQn2l8o/HiZVyCBKsznU=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resources/emailtemplate.go
+++ b/internal/provider/resources/emailtemplate.go
@@ -183,11 +183,11 @@ func emailTemplatePrebuiltCustomizationModelFromEmailTemplate(e emailtemplates.E
 		if e.PrebuiltCustomization.ButtonTextColor != nil {
 			prebuiltCustomization.ButtonTextColor = types.StringValue(*e.PrebuiltCustomization.ButtonTextColor)
 		}
-		if e.PrebuiltCustomization.FontFamily != nil {
-			prebuiltCustomization.FontFamily = types.StringValue(string(*e.PrebuiltCustomization.FontFamily))
+		if e.PrebuiltCustomization.FontFamily != emailtemplates.FontFamilyUnknown {
+			prebuiltCustomization.FontFamily = types.StringValue(string(e.PrebuiltCustomization.FontFamily))
 		}
-		if e.PrebuiltCustomization.TextAlignment != nil {
-			prebuiltCustomization.TextAlignment = types.StringValue(string(*e.PrebuiltCustomization.TextAlignment))
+		if e.PrebuiltCustomization.TextAlignment != emailtemplates.TextAlignmentUnknown {
+			prebuiltCustomization.TextAlignment = types.StringValue(string(e.PrebuiltCustomization.TextAlignment))
 		}
 	}
 	return prebuiltCustomization
@@ -275,10 +275,10 @@ func (m emailTemplateModel) toEmailTemplate(ctx context.Context) (emailtemplates
 			e.PrebuiltCustomization.ButtonTextColor = ptr(prebuiltCustomization.ButtonTextColor.ValueString())
 		}
 		if !prebuiltCustomization.FontFamily.IsUnknown() {
-			e.PrebuiltCustomization.FontFamily = ptr(emailtemplates.FontFamily(prebuiltCustomization.FontFamily.ValueString()))
+			e.PrebuiltCustomization.FontFamily = emailtemplates.FontFamily(prebuiltCustomization.FontFamily.ValueString())
 		}
 		if !prebuiltCustomization.TextAlignment.IsUnknown() {
-			e.PrebuiltCustomization.TextAlignment = ptr(emailtemplates.TextAlignment(prebuiltCustomization.TextAlignment.ValueString()))
+			e.PrebuiltCustomization.TextAlignment = emailtemplates.TextAlignment(prebuiltCustomization.TextAlignment.ValueString())
 		}
 	}
 

--- a/internal/provider/resources/environment.go
+++ b/internal/provider/resources/environment.go
@@ -40,7 +40,7 @@ type environmentResourceModel struct {
 	ProjectSlug                                            types.String `tfsdk:"project_slug"`
 	EnvironmentSlug                                        types.String `tfsdk:"environment_slug"`
 	Name                                                   types.String `tfsdk:"name"`
-	OauthCallbackID                                        types.String `tfsdk:"oauth_callback_id"`
+	OAuthCallbackID                                        types.String `tfsdk:"oauth_callback_id"`
 	CrossOrgPasswordsEnabled                               types.Bool   `tfsdk:"cross_org_passwords_enabled"`
 	UserImpersonationEnabled                               types.Bool   `tfsdk:"user_impersonation_enabled"`
 	ZeroDowntimeSessionMigrationURL                        types.String `tfsdk:"zero_downtime_session_migration_url"`
@@ -235,10 +235,10 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.UserLockSelfServeEnabled = ptr(plan.UserLockSelfServeEnabled.ValueBool())
 	}
 	if !plan.UserLockThreshold.IsNull() && !plan.UserLockThreshold.IsUnknown() {
-		createReq.UserLockThreshold = ptr(plan.UserLockThreshold.ValueInt32())
+		createReq.UserLockThreshold = ptr(int(plan.UserLockThreshold.ValueInt32()))
 	}
 	if !plan.UserLockTTL.IsNull() && !plan.UserLockTTL.IsUnknown() {
-		createReq.UserLockTTL = ptr(plan.UserLockTTL.ValueInt32())
+		createReq.UserLockTTL = ptr(int(plan.UserLockTTL.ValueInt32()))
 	}
 	if !plan.IDPAuthorizationURL.IsNull() && !plan.IDPAuthorizationURL.IsUnknown() {
 		createReq.IDPAuthorizationURL = ptr(plan.IDPAuthorizationURL.ValueString())
@@ -345,10 +345,10 @@ func (r *environmentResource) Update(ctx context.Context, req resource.UpdateReq
 		updateReq.UserLockSelfServeEnabled = ptr(plan.UserLockSelfServeEnabled.ValueBool())
 	}
 	if !plan.UserLockThreshold.IsNull() && !plan.UserLockThreshold.Equal(state.UserLockThreshold) {
-		updateReq.UserLockThreshold = ptr(plan.UserLockThreshold.ValueInt32())
+		updateReq.UserLockThreshold = ptr(int(plan.UserLockThreshold.ValueInt32()))
 	}
 	if !plan.UserLockTTL.IsNull() && !plan.UserLockTTL.Equal(state.UserLockTTL) {
-		updateReq.UserLockTTL = ptr(plan.UserLockTTL.ValueInt32())
+		updateReq.UserLockTTL = ptr(int(plan.UserLockTTL.ValueInt32()))
 	}
 	if !plan.IDPAuthorizationURL.IsNull() && !plan.IDPAuthorizationURL.Equal(state.IDPAuthorizationURL) {
 		updateReq.IDPAuthorizationURL = ptr(plan.IDPAuthorizationURL.ValueString())
@@ -426,13 +426,13 @@ func refreshFromEnvironment(env environments.Environment) environmentResourceMod
 		ProjectSlug:                         types.StringValue(env.ProjectSlug),
 		EnvironmentSlug:                     types.StringValue(env.EnvironmentSlug),
 		Name:                                types.StringValue(env.Name),
-		OauthCallbackID:                     types.StringValue(env.OauthCallbackID),
+		OAuthCallbackID:                     types.StringValue(env.OAuthCallbackID),
 		CrossOrgPasswordsEnabled:            types.BoolValue(env.CrossOrgPasswordsEnabled),
 		UserImpersonationEnabled:            types.BoolValue(env.UserImpersonationEnabled),
 		ZeroDowntimeSessionMigrationURL:     types.StringValue(env.ZeroDowntimeSessionMigrationURL),
 		UserLockSelfServeEnabled:            types.BoolValue(env.UserLockSelfServeEnabled),
-		UserLockThreshold:                   types.Int32Value(env.UserLockThreshold),
-		UserLockTTL:                         types.Int32Value(env.UserLockTTL),
+		UserLockThreshold:                   types.Int32Value(int32(env.UserLockThreshold)),
+		UserLockTTL:                         types.Int32Value(int32(env.UserLockTTL)),
 		IDPAuthorizationURL:                 types.StringValue(env.IDPAuthorizationURL),
 		IDPDynamicClientRegistrationEnabled: types.BoolValue(env.IDPDynamicClientRegistrationEnabled),
 		IDPDynamicClientRegistrationAccessTokenTemplateContent: types.StringValue(env.IDPDynamicClientRegistrationAccessTokenTemplateContent),

--- a/internal/provider/resources/eventlogstreaming.go
+++ b/internal/provider/resources/eventlogstreaming.go
@@ -154,8 +154,8 @@ var grafanaLokiConfigModelAttrTypes = map[string]attr.Type{
 
 // refreshFromEventLogStreaming updates the model from a full API response (used in Create/Update)
 // Note: This does NOT update the Enabled field - that should be managed separately since
-// Enable/Disable are separate API calls that don't return the config
-func (m *eventLogStreamingModel) refreshFromEventLogStreaming(ctx context.Context, r eventlogstreaming.EventLogStreamingConfig) diag.Diagnostics {
+// Enable/Disable are separate API calls that don't return the config.
+func (m *eventLogStreamingModel) refreshFromEventLogStreaming(ctx context.Context, r eventlogstreaming.EventLogStreaming) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Don't update Enabled - it's managed separately via Enable/Disable calls
@@ -190,8 +190,8 @@ func (m *eventLogStreamingModel) refreshFromEventLogStreaming(ctx context.Contex
 	return diags
 }
 
-// refreshFromMaskedEventLogStreaming updates the model from a masked API response (used in Read/Import)
-func (m *eventLogStreamingModel) refreshFromMaskedEventLogStreaming(ctx context.Context, r eventlogstreaming.EventLogStreamingConfigMasked) diag.Diagnostics {
+// refreshFromMaskedEventLogStreaming updates the model from a masked API response (used in Read/Import).
+func (m *eventLogStreamingModel) refreshFromMaskedEventLogStreaming(ctx context.Context, r eventlogstreaming.EventLogStreamingMasked) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	m.Enabled = types.BoolValue(r.StreamingStatus == eventlogstreaming.StreamingStatusActive)
@@ -305,7 +305,7 @@ func (r *eventLogStreamingResource) upgradeEventLogStreamingStateV0ToV1(
 	destinationType := strings.ToUpper(prior.DestinationType.ValueString())
 	destinationTypeEnum := eventlogstreaming.DestinationType(destinationType)
 
-	getResp, err := r.client.EventLogStreaming.Get(ctx, eventlogstreaming.GetEventLogStreamingRequest{
+	getResp, err := r.client.EventLogStreaming.Get(ctx, eventlogstreaming.GetRequest{
 		ProjectSlug:     projectSlug,
 		EnvironmentSlug: environmentSlug,
 		DestinationType: destinationTypeEnum,
@@ -511,7 +511,7 @@ func (r *eventLogStreamingResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	// Create the streaming config
-	createResp, err := r.client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+	createResp, err := r.client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateRequest{
 		ProjectSlug:       plan.ProjectSlug.ValueString(),
 		EnvironmentSlug:   plan.EnvironmentSlug.ValueString(),
 		DestinationType:   eventlogstreaming.DestinationType(plan.DestinationType.ValueString()),
@@ -526,7 +526,7 @@ func (r *eventLogStreamingResource) Create(ctx context.Context, req resource.Cre
 
 	// Handle enabled/disabled status - newly created configs are disabled by default
 	if !plan.Enabled.IsUnknown() && !plan.Enabled.IsNull() && plan.Enabled.ValueBool() {
-		_, err := r.client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableEventLogStreamingRequest{
+		_, err := r.client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableRequest{
 			ProjectSlug:     plan.ProjectSlug.ValueString(),
 			EnvironmentSlug: plan.EnvironmentSlug.ValueString(),
 			DestinationType: eventlogstreaming.DestinationType(plan.DestinationType.ValueString()),
@@ -565,7 +565,7 @@ func (r *eventLogStreamingResource) Read(ctx context.Context, req resource.ReadR
 	ctx = tflog.SetField(ctx, "destination_type", state.DestinationType.ValueString())
 	tflog.Info(ctx, "Reading event log streaming")
 
-	getResp, err := r.client.EventLogStreaming.Get(ctx, eventlogstreaming.GetEventLogStreamingRequest{
+	getResp, err := r.client.EventLogStreaming.Get(ctx, eventlogstreaming.GetRequest{
 		ProjectSlug:     state.ProjectSlug.ValueString(),
 		EnvironmentSlug: state.EnvironmentSlug.ValueString(),
 		DestinationType: eventlogstreaming.DestinationType(state.DestinationType.ValueString()),
@@ -613,7 +613,7 @@ func (r *eventLogStreamingResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	// Update the streaming config
-	updateResp, err := r.client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
+	updateResp, err := r.client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateRequest{
 		ProjectSlug:       plan.ProjectSlug.ValueString(),
 		EnvironmentSlug:   plan.EnvironmentSlug.ValueString(),
 		DestinationType:   eventlogstreaming.DestinationType(plan.DestinationType.ValueString()),
@@ -629,7 +629,7 @@ func (r *eventLogStreamingResource) Update(ctx context.Context, req resource.Upd
 	// Handle enabled/disabled status changes
 	if !plan.Enabled.IsUnknown() && !plan.Enabled.IsNull() && plan.Enabled.ValueBool() != state.Enabled.ValueBool() {
 		if plan.Enabled.ValueBool() {
-			_, err := r.client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableEventLogStreamingRequest{
+			_, err := r.client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableRequest{
 				ProjectSlug:     plan.ProjectSlug.ValueString(),
 				EnvironmentSlug: plan.EnvironmentSlug.ValueString(),
 				DestinationType: eventlogstreaming.DestinationType(plan.DestinationType.ValueString()),
@@ -639,7 +639,7 @@ func (r *eventLogStreamingResource) Update(ctx context.Context, req resource.Upd
 				return
 			}
 		} else {
-			_, err := r.client.EventLogStreaming.Disable(ctx, eventlogstreaming.DisableEventLogStreamingRequest{
+			_, err := r.client.EventLogStreaming.Disable(ctx, eventlogstreaming.DisableRequest{
 				ProjectSlug:     plan.ProjectSlug.ValueString(),
 				EnvironmentSlug: plan.EnvironmentSlug.ValueString(),
 				DestinationType: eventlogstreaming.DestinationType(plan.DestinationType.ValueString()),
@@ -677,7 +677,7 @@ func (r *eventLogStreamingResource) Delete(ctx context.Context, req resource.Del
 	ctx = tflog.SetField(ctx, "destination_type", state.DestinationType.ValueString())
 	tflog.Info(ctx, "Deleting event log streaming")
 
-	_, err := r.client.EventLogStreaming.Delete(ctx, eventlogstreaming.DeleteEventLogStreamingRequest{
+	_, err := r.client.EventLogStreaming.Delete(ctx, eventlogstreaming.DeleteRequest{
 		ProjectSlug:     state.ProjectSlug.ValueString(),
 		EnvironmentSlug: state.EnvironmentSlug.ValueString(),
 		DestinationType: eventlogstreaming.DestinationType(state.DestinationType.ValueString()),
@@ -711,7 +711,7 @@ func (r *eventLogStreamingResource) ImportState(ctx context.Context, req resourc
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("destination_type"), destinationType)...)
 }
 
-func (r *eventLogStreamingResource) buildDestinationConfig(ctx context.Context, model *eventLogStreamingModel) (eventlogstreaming.DestinationConfig, diag.Diagnostics) {
+func (r *eventLogStreamingResource) buildDestinationConfig(ctx context.Context, model *eventLogStreamingModel) (*eventlogstreaming.DestinationConfig, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	var destConfig eventlogstreaming.DestinationConfig
 
@@ -721,13 +721,13 @@ func (r *eventLogStreamingResource) buildDestinationConfig(ctx context.Context, 
 	case "DATADOG":
 		if model.DatadogConfig.IsNull() || model.DatadogConfig.IsUnknown() {
 			diags.AddError("Missing Datadog Configuration", "datadog_config configuration is required when destination_type is DATADOG")
-			return destConfig, diags
+			return &destConfig, diags
 		}
 
 		var datadog datadogConfigModel
 		diags.Append(model.DatadogConfig.As(ctx, &datadog, basetypes.ObjectAsOptions{})...)
 		if diags.HasError() {
-			return destConfig, diags
+			return &destConfig, diags
 		}
 
 		destConfig.Datadog = &eventlogstreaming.DatadogConfig{
@@ -738,13 +738,13 @@ func (r *eventLogStreamingResource) buildDestinationConfig(ctx context.Context, 
 	case "GRAFANA_LOKI":
 		if model.GrafanaLokiConfig.IsNull() || model.GrafanaLokiConfig.IsUnknown() {
 			diags.AddError("Missing Grafana Loki Configuration", "grafana_loki_config configuration is required when destination_type is GRAFANA_LOKI")
-			return destConfig, diags
+			return &destConfig, diags
 		}
 
 		var grafana grafanaLokiConfigModel
 		diags.Append(model.GrafanaLokiConfig.As(ctx, &grafana, basetypes.ObjectAsOptions{})...)
 		if diags.HasError() {
-			return destConfig, diags
+			return &destConfig, diags
 		}
 
 		destConfig.GrafanaLoki = &eventlogstreaming.GrafanaLokiConfig{
@@ -757,5 +757,5 @@ func (r *eventLogStreamingResource) buildDestinationConfig(ctx context.Context, 
 		diags.AddError("Invalid Destination Type", fmt.Sprintf("Unsupported destination_type: %s", destType))
 	}
 
-	return destConfig, diags
+	return &destConfig, diags
 }

--- a/internal/provider/resources/eventlogstreaming_test.go
+++ b/internal/provider/resources/eventlogstreaming_test.go
@@ -68,12 +68,12 @@ func TestAccEventLogStreamingResource(t *testing.T) {
 			TestName:        "datadog",
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			InitialDatadogConfig: eventlogstreaming.DatadogConfig{
-				Site:   eventlogstreaming.DatadogSiteUS,
+				Site:   eventlogstreaming.DatadogSiteUs,
 				APIKey: "0123456789abcdef0123456789abcdef",
 			},
 			InitialGrafanaLokiConfig: eventlogstreaming.GrafanaLokiConfig{},
 			UpdatedDatadogConfig: eventlogstreaming.DatadogConfig{
-				Site:   eventlogstreaming.DatadogSiteEU,
+				Site:   eventlogstreaming.DatadogSiteEu,
 				APIKey: "ffffffffffffffffffffffffffffffff",
 			},
 			UpdatedGrafanaLokiConfig: eventlogstreaming.GrafanaLokiConfig{},

--- a/internal/provider/resources/jwttemplate.go
+++ b/internal/provider/resources/jwttemplate.go
@@ -124,7 +124,7 @@ func (r *jwtTemplateResource) upgradeJWTTemplateStateV0ToV1(
 		return
 	}
 
-	getResp, err := r.client.JWTTemplates.Get(ctx, &jwttemplates.GetRequest{
+	getResp, err := r.client.JWTTemplates.Get(ctx, jwttemplates.GetRequest{
 		ProjectSlug:     projectSlug,
 		EnvironmentSlug: environmentSlug,
 		JWTTemplateType: jwttemplates.JWTTemplateType(strings.ToUpper(prior.TemplateType.ValueString())),
@@ -208,7 +208,7 @@ func (r *jwtTemplateResource) Schema(_ context.Context, _ resource.SchemaRequest
 	}
 }
 
-// updateModelFromAPI updates the model with values from the API response
+// updateModelFromAPI updates the model with values from the API response.
 func (r *jwtTemplateResource) updateModelFromAPI(model *jwtTemplateModel, template *jwttemplates.JWTTemplate) {
 	model.ID = types.StringValue(fmt.Sprintf("%s.%s.%s", model.ProjectSlug.ValueString(), model.EnvironmentSlug.ValueString(), model.TemplateType.ValueString()))
 	model.TemplateContent = types.StringValue(template.TemplateContent)
@@ -229,7 +229,7 @@ func (r *jwtTemplateResource) Create(ctx context.Context, req resource.CreateReq
 	ctx = tflog.SetField(ctx, "template_type", plan.TemplateType.ValueString())
 	tflog.Info(ctx, "Creating JWT template")
 
-	createResp, err := r.client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
+	createResp, err := r.client.JWTTemplates.Set(ctx, jwttemplates.SetRequest{
 		ProjectSlug:     plan.ProjectSlug.ValueString(),
 		EnvironmentSlug: plan.EnvironmentSlug.ValueString(),
 		JWTTemplateType: jwttemplates.JWTTemplateType(plan.TemplateType.ValueString()),
@@ -264,7 +264,7 @@ func (r *jwtTemplateResource) Read(ctx context.Context, req resource.ReadRequest
 	ctx = tflog.SetField(ctx, "template_type", state.TemplateType.ValueString())
 	tflog.Info(ctx, "Reading JWT template")
 
-	getResp, err := r.client.JWTTemplates.Get(ctx, &jwttemplates.GetRequest{
+	getResp, err := r.client.JWTTemplates.Get(ctx, jwttemplates.GetRequest{
 		ProjectSlug:     state.ProjectSlug.ValueString(),
 		EnvironmentSlug: state.EnvironmentSlug.ValueString(),
 		JWTTemplateType: jwttemplates.JWTTemplateType(state.TemplateType.ValueString()),
@@ -296,7 +296,7 @@ func (r *jwtTemplateResource) Update(ctx context.Context, req resource.UpdateReq
 	ctx = tflog.SetField(ctx, "template_type", plan.TemplateType.ValueString())
 	tflog.Info(ctx, "Updating JWT template")
 
-	updateResp, err := r.client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
+	updateResp, err := r.client.JWTTemplates.Set(ctx, jwttemplates.SetRequest{
 		ProjectSlug:     plan.ProjectSlug.ValueString(),
 		EnvironmentSlug: plan.EnvironmentSlug.ValueString(),
 		JWTTemplateType: jwttemplates.JWTTemplateType(plan.TemplateType.ValueString()),
@@ -333,7 +333,7 @@ func (r *jwtTemplateResource) Delete(ctx context.Context, req resource.DeleteReq
 	tflog.Info(ctx, "Deleting JWT template (resetting to default values)")
 
 	// JWT templates cannot be deleted via API, only reset to empty/default values
-	_, err := r.client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
+	_, err := r.client.JWTTemplates.Set(ctx, jwttemplates.SetRequest{
 		ProjectSlug:     state.ProjectSlug.ValueString(),
 		EnvironmentSlug: state.EnvironmentSlug.ValueString(),
 		JWTTemplateType: jwttemplates.JWTTemplateType(state.TemplateType.ValueString()),

--- a/internal/provider/resources/password_config.go
+++ b/internal/provider/resources/password_config.go
@@ -232,7 +232,7 @@ func (r *passwordConfigResource) Schema(
 				Description: "The policy to use for password validation. Valid values: LUDS, ZXCVBN.",
 				Validators: []validator.String{
 					stringvalidator.OneOf(
-						toStrings(passwordstrengthconfig.ValidationPolicies())...),
+						toStrings(passwordstrengthconfig.ValidationPolicys())...),
 				},
 			},
 			"luds_min_password_length": schema.Int64Attribute{
@@ -500,7 +500,7 @@ func (v *ludsFieldsValidator) ValidateResource(ctx context.Context, req resource
 	}
 }
 
-// updateModelFromAPI updates the model with values from the API response
+// updateModelFromAPI updates the model with values from the API response.
 func (r *passwordConfigResource) updateModelFromAPI(model *passwordConfigModel, config *passwordstrengthconfig.PasswordStrengthConfig) {
 	model.CheckBreachOnCreation = types.BoolValue(config.CheckBreachOnCreation)
 	model.CheckBreachOnAuthentication = types.BoolValue(config.CheckBreachOnAuthentication)

--- a/internal/provider/resources/project.go
+++ b/internal/provider/resources/project.go
@@ -71,7 +71,7 @@ var projectResourceLegacySchema = schema.Schema{
 type environmentModel struct {
 	EnvironmentSlug                                        types.String `tfsdk:"environment_slug"`
 	Name                                                   types.String `tfsdk:"name"`
-	OauthCallbackID                                        types.String `tfsdk:"oauth_callback_id"`
+	OAuthCallbackID                                        types.String `tfsdk:"oauth_callback_id"`
 	CrossOrgPasswordsEnabled                               types.Bool   `tfsdk:"cross_org_passwords_enabled"`
 	UserImpersonationEnabled                               types.Bool   `tfsdk:"user_impersonation_enabled"`
 	ZeroDowntimeSessionMigrationURL                        types.String `tfsdk:"zero_downtime_session_migration_url"`
@@ -700,10 +700,10 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 			updateEnvReq.UserLockSelfServeEnabled = ptr(liveEnvPlan.UserLockSelfServeEnabled.ValueBool())
 		}
 		if !liveEnvPlan.UserLockThreshold.IsNull() && !liveEnvPlan.UserLockThreshold.Equal(liveEnvState.UserLockThreshold) {
-			updateEnvReq.UserLockThreshold = ptr(liveEnvPlan.UserLockThreshold.ValueInt32())
+			updateEnvReq.UserLockThreshold = ptr(int(liveEnvPlan.UserLockThreshold.ValueInt32()))
 		}
 		if !liveEnvPlan.UserLockTTL.IsNull() && !liveEnvPlan.UserLockTTL.Equal(liveEnvState.UserLockTTL) {
-			updateEnvReq.UserLockTTL = ptr(liveEnvPlan.UserLockTTL.ValueInt32())
+			updateEnvReq.UserLockTTL = ptr(int(liveEnvPlan.UserLockTTL.ValueInt32()))
 		}
 		if !liveEnvPlan.IDPAuthorizationURL.IsNull() && !liveEnvPlan.IDPAuthorizationURL.Equal(liveEnvState.IDPAuthorizationURL) {
 			updateEnvReq.IDPAuthorizationURL = ptr(liveEnvPlan.IDPAuthorizationURL.ValueString())
@@ -772,13 +772,13 @@ func refreshFromLiveEnv(env environments.Environment) environmentModel {
 	return environmentModel{
 		EnvironmentSlug:                     types.StringValue(env.EnvironmentSlug),
 		Name:                                types.StringValue(env.Name),
-		OauthCallbackID:                     types.StringValue(env.OauthCallbackID),
+		OAuthCallbackID:                     types.StringValue(env.OAuthCallbackID),
 		CrossOrgPasswordsEnabled:            types.BoolValue(env.CrossOrgPasswordsEnabled),
 		UserImpersonationEnabled:            types.BoolValue(env.UserImpersonationEnabled),
 		ZeroDowntimeSessionMigrationURL:     types.StringValue(env.ZeroDowntimeSessionMigrationURL),
 		UserLockSelfServeEnabled:            types.BoolValue(env.UserLockSelfServeEnabled),
-		UserLockThreshold:                   types.Int32Value(env.UserLockThreshold),
-		UserLockTTL:                         types.Int32Value(env.UserLockTTL),
+		UserLockThreshold:                   types.Int32Value(int32(env.UserLockThreshold)),
+		UserLockTTL:                         types.Int32Value(int32(env.UserLockTTL)),
 		IDPAuthorizationURL:                 types.StringValue(env.IDPAuthorizationURL),
 		IDPDynamicClientRegistrationEnabled: types.BoolValue(env.IDPDynamicClientRegistrationEnabled),
 		IDPDynamicClientRegistrationAccessTokenTemplateContent: types.StringValue(env.IDPDynamicClientRegistrationAccessTokenTemplateContent),
@@ -809,10 +809,10 @@ func buildEnvironmentCreateRequest(projectSlug string, liveEnvPlan environmentMo
 		createEnvReq.UserLockSelfServeEnabled = ptr(liveEnvPlan.UserLockSelfServeEnabled.ValueBool())
 	}
 	if !liveEnvPlan.UserLockThreshold.IsNull() && !liveEnvPlan.UserLockThreshold.IsUnknown() {
-		createEnvReq.UserLockThreshold = ptr(liveEnvPlan.UserLockThreshold.ValueInt32())
+		createEnvReq.UserLockThreshold = ptr(int(liveEnvPlan.UserLockThreshold.ValueInt32()))
 	}
 	if !liveEnvPlan.UserLockTTL.IsNull() && !liveEnvPlan.UserLockTTL.IsUnknown() {
-		createEnvReq.UserLockTTL = ptr(liveEnvPlan.UserLockTTL.ValueInt32())
+		createEnvReq.UserLockTTL = ptr(int(liveEnvPlan.UserLockTTL.ValueInt32()))
 	}
 	if !liveEnvPlan.IDPAuthorizationURL.IsNull() && !liveEnvPlan.IDPAuthorizationURL.IsUnknown() {
 		createEnvReq.IDPAuthorizationURL = ptr(liveEnvPlan.IDPAuthorizationURL.ValueString())

--- a/internal/provider/resources/rbacpolicy_test.go
+++ b/internal/provider/resources/rbacpolicy_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stytchauth/terraform-provider-stytch/internal/provider/testutil"
 )
 
-// TestAccRBACPolicyResource_B2B tests RBAC policy for B2B projects
+// TestAccRBACPolicyResource_B2B tests RBAC policy for B2B projects.
 func TestAccRBACPolicyResource_B2B(t *testing.T) {
 	for _, testCase := range []testutil.TestCase{
 		{
@@ -191,7 +191,7 @@ func TestAccRBACPolicyResource_B2B(t *testing.T) {
 	}
 }
 
-// TestAccRBACPolicyResource_Consumer tests RBAC policy for Consumer projects
+// TestAccRBACPolicyResource_Consumer tests RBAC policy for Consumer projects.
 func TestAccRBACPolicyResource_Consumer(t *testing.T) {
 	for _, testCase := range []testutil.TestCase{
 		{

--- a/internal/provider/resources/redirecturl.go
+++ b/internal/provider/resources/redirecturl.go
@@ -247,7 +247,7 @@ func (r *redirectURLResource) Schema(_ context.Context, _ resource.SchemaRequest
 							Required:    true,
 							Description: "The type of the redirect URL.",
 							Validators: []validator.String{
-								stringvalidator.OneOf(toStrings(redirecturls.RedirectTypes())...),
+								stringvalidator.OneOf(toStrings(redirecturls.RedirectURLTypes())...),
 							},
 						},
 						"is_default": schema.BoolAttribute{
@@ -261,8 +261,8 @@ func (r *redirectURLResource) Schema(_ context.Context, _ resource.SchemaRequest
 	}
 }
 
-func (m redirectURLModel) toValidTypes() []redirecturls.URLRedirectType {
-	var validTypes []redirecturls.URLRedirectType
+func (m redirectURLModel) toValidTypes() []redirecturls.URLType {
+	var validTypes []redirecturls.URLType
 
 	if m.ValidTypes.IsNull() || m.ValidTypes.IsUnknown() {
 		return validTypes
@@ -278,8 +278,8 @@ func (m redirectURLModel) toValidTypes() []redirecturls.URLRedirectType {
 				continue
 			}
 
-			validTypes = append(validTypes, redirecturls.URLRedirectType{
-				Type:      redirecturls.RedirectType(typeAttr.ValueString()),
+			validTypes = append(validTypes, redirecturls.URLType{
+				Type:      redirecturls.RedirectURLType(typeAttr.ValueString()),
 				IsDefault: isDefaultAttr.ValueBool(),
 			})
 		}
@@ -310,7 +310,7 @@ func (r *redirectURLResource) Create(ctx context.Context, req resource.CreateReq
 		// We explicitly disable default promotion logic because if the terraform provisioner specified that a redirect URL
 		// is *not* the default for a given type, if the API tries to override it to true, it will result in a provider
 		// inconsistency error.
-		DoNotPromoteDefaults: true,
+		DoNotPromoteDefaults: ptr(true),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create redirect URL", err.Error())
@@ -385,7 +385,7 @@ func (r *redirectURLResource) Update(ctx context.Context, req resource.UpdateReq
 		// We explicitly disable default promotion logic because if the terraform provisioner specified that a redirect URL
 		// is *not* the default for a given type, if the API tries to override it to true, it will result in a provider
 		// inconsistency error.
-		DoNotPromoteDefaults: true,
+		DoNotPromoteDefaults: ptr(true),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update redirect URL", err.Error())
@@ -424,7 +424,7 @@ func (r *redirectURLResource) Delete(ctx context.Context, req resource.DeleteReq
 		// We explicitly disable default promotion logic because if the terraform provisioner specified that a redirect URL
 		// is *not* the default for a given type, if the API tries to override it to true, it will result in a provider
 		// inconsistency error.
-		DoNotPromoteDefaults: true,
+		DoNotPromoteDefaults: ptr(true),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to delete redirect URL", err.Error())

--- a/internal/provider/resources/redirecturl_test.go
+++ b/internal/provider/resources/redirecturl_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stytchauth/terraform-provider-stytch/internal/provider/testutil"
 )
 
-func redirectType(typ redirecturls.RedirectType, isDefault bool) string {
+func redirectType(typ redirecturls.RedirectURLType, isDefault bool) string {
 	return fmt.Sprintf(`{type = "%s", is_default = %t}`, typ, isDefault)
 }
 
@@ -33,15 +33,15 @@ resource "stytch_redirect_url" "test" {
 func TestAccRedirectURLResource(t *testing.T) {
 	for _, testCase := range []struct {
 		name          string
-		redirectTypes []redirecturls.URLRedirectType
+		redirectTypes []redirecturls.URLType
 	}{
-		{name: "login-only", redirectTypes: []redirecturls.URLRedirectType{
-			{Type: redirecturls.RedirectTypeLogin, IsDefault: true},
+		{name: "login-only", redirectTypes: []redirecturls.URLType{
+			{Type: redirecturls.RedirectURLTypeLogin, IsDefault: true},
 		}},
-		{name: "multiple", redirectTypes: []redirecturls.URLRedirectType{
-			{Type: redirecturls.RedirectTypeLogin, IsDefault: true},
-			{Type: redirecturls.RedirectTypeSignup, IsDefault: true},
-			{Type: redirecturls.RedirectTypeResetPassword, IsDefault: true},
+		{name: "multiple", redirectTypes: []redirecturls.URLType{
+			{Type: redirecturls.RedirectURLTypeLogin, IsDefault: true},
+			{Type: redirecturls.RedirectURLTypeSignup, IsDefault: true},
+			{Type: redirecturls.RedirectURLTypeResetPassword, IsDefault: true},
 		}},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -74,10 +74,10 @@ func TestAccRedirectURLResource(t *testing.T) {
 					},
 					{
 						// Update and Read testing - change to *only* signup redirect
-						Config: testutil.ProviderConfig + redirectURLResource(redirectType(redirecturls.RedirectTypeSignup, true)),
+						Config: testutil.ProviderConfig + redirectURLResource(redirectType(redirecturls.RedirectURLTypeSignup, true)),
 						Check: resource.ComposeAggregateTestCheckFunc(
 							resource.TestCheckResourceAttr("stytch_redirect_url.test", "url", "http://localhost:3000/consumer"),
-							resource.TestCheckResourceAttr("stytch_redirect_url.test", "valid_types.0.type", string(redirecturls.RedirectTypeSignup)),
+							resource.TestCheckResourceAttr("stytch_redirect_url.test", "valid_types.0.type", string(redirecturls.RedirectURLTypeSignup)),
 							resource.TestCheckResourceAttr("stytch_redirect_url.test", "valid_types.0.is_default", "true"),
 						),
 					},

--- a/internal/provider/resources/secret.go
+++ b/internal/provider/resources/secret.go
@@ -204,7 +204,7 @@ func (r *secretResource) Create(
 	ctx = tflog.SetField(ctx, "environment_slug", plan.EnvironmentSlug.ValueString())
 	tflog.Info(ctx, "Creating secret")
 
-	createResp, err := r.client.Secrets.Create(ctx, secrets.CreateSecretRequest{
+	createResp, err := r.client.Secrets.Create(ctx, secrets.CreateRequest{
 		ProjectSlug:     plan.ProjectSlug.ValueString(),
 		EnvironmentSlug: plan.EnvironmentSlug.ValueString(),
 	})
@@ -213,14 +213,14 @@ func (r *secretResource) Create(
 		return
 	}
 
-	ctx = tflog.SetField(ctx, "secret_id", createResp.CreatedSecret.SecretID)
-	ctx = tflog.SetField(ctx, "secret", createResp.CreatedSecret.Secret)
+	ctx = tflog.SetField(ctx, "secret_id", createResp.Secret.SecretID)
+	ctx = tflog.SetField(ctx, "secret", createResp.Secret.Secret)
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "secret")
 	tflog.Info(ctx, "Created secret")
 
-	plan.SecretID = types.StringValue(createResp.CreatedSecret.SecretID)
-	plan.CreatedAt = types.StringValue(createResp.CreatedSecret.CreatedAt.Format(time.RFC3339))
-	plan.Secret = types.StringValue(createResp.CreatedSecret.Secret)
+	plan.SecretID = types.StringValue(createResp.Secret.SecretID)
+	plan.CreatedAt = types.StringValue(createResp.Secret.CreatedAt.Format(time.RFC3339))
+	plan.Secret = types.StringValue(createResp.Secret.Secret)
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -245,7 +245,7 @@ func (r *secretResource) Read(
 	tflog.Info(ctx, "Reading secret")
 
 	// We call Get here just to verify the secret still exists, but there is no state to update.
-	_, err := r.client.Secrets.Get(ctx, secrets.GetSecretRequest{
+	_, err := r.client.Secrets.Get(ctx, secrets.GetRequest{
 		ProjectSlug:     state.ProjectSlug.ValueString(),
 		EnvironmentSlug: state.EnvironmentSlug.ValueString(),
 		SecretID:        state.SecretID.ValueString(),
@@ -291,7 +291,7 @@ func (r *secretResource) Delete(
 	ctx = tflog.SetField(ctx, "secret_id", state.SecretID.ValueString())
 	tflog.Info(ctx, "Deleting secret")
 
-	_, err := r.client.Secrets.Delete(ctx, secrets.DeleteSecretRequest{
+	_, err := r.client.Secrets.Delete(ctx, secrets.DeleteRequest{
 		ProjectSlug:     state.ProjectSlug.ValueString(),
 		EnvironmentSlug: state.EnvironmentSlug.ValueString(),
 		SecretID:        state.SecretID.ValueString(),


### PR DESCRIPTION
Exposes a few *slightly* odd codegen fields/enums, but overall it doesn't look too bad. I'm on the fence for how much we want to try to change them. I also changed instances of `int32` to `int` in the SDK, but TF is still using int32 (and I didn't want to change this just in case it breaks some sort of backwards compatibility).

I also disabled `godot` because it provides some annoying lint advice like "comments must end in a period."