### PR TITLE
[V3] Enforce at least length of 1 in `valid_types` set

### DIFF
--- a/internal/provider/resources/redirecturl.go
+++ b/internal/provider/resources/redirecturl.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -241,6 +242,9 @@ func (r *redirectURLResource) Schema(_ context.Context, _ resource.SchemaRequest
 			"valid_types": schema.SetNestedAttribute{
 				Description: "The set of valid types for the redirect URL.",
 				Required:    true,
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{

--- a/internal/provider/resources/redirecturl_test.go
+++ b/internal/provider/resources/redirecturl_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -143,5 +144,30 @@ resource "stytch_redirect_url" "test" {
 
 	resource.Test(t, resource.TestCase{
 		Steps: testutil.StateUpgradeTestSteps(v1Config, v3Config),
+	})
+}
+
+func TestRedirectURLValidTypesValidation(t *testing.T) {
+	t.Run("valid_types must have at least one element", func(t *testing.T) {
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					// Test that empty valid_types produces an error
+					Config: testutil.ProviderConfig + testutil.ConsumerProjectConfig + testutil.EnvironmentResource(testutil.EnvironmentResourceArgs{
+						ProjectSlug: "stytch_project.test.project_slug",
+						Name:        "Test Environment",
+					}) + `
+resource "stytch_redirect_url" "test" {
+  project_slug     = stytch_project.test.project_slug
+  environment_slug = stytch_environment.test.environment_slug
+  url              = "http://localhost:3000/consumer"
+  valid_types      = []
+}
+`,
+					ExpectError: regexp.MustCompile("Attribute valid_types set must contain at least 1"),
+				},
+			},
+		})
 	})
 }

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "3.0.0-alpha.3"
+const Version = "3.0.0-alpha.4"


### PR DESCRIPTION
## Description

- Enforces a length of at least 1
-  Bumps patch alpha version

## Testing

Added a unit test

```
go test -v -timeout 30m ./internal/provider/resources -run TestRedirectURLValidTypesValidation
=== RUN   TestRedirectURLValidTypesValidation
=== RUN   TestRedirectURLValidTypesValidation/valid_types_must_have_at_least_one_element
--- PASS: TestRedirectURLValidTypesValidation (1.76s)
    --- PASS: TestRedirectURLValidTypesValidation/valid_types_must_have_at_least_one_element (1.76s)
PASS
ok      github.com/stytchauth/terraform-provider-stytch/internal/provider/resources     2.702s
```