### PR TITLE
Prepare for v3.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 The Stytch Terraform Provider is the official plugin for managing your Stytch workspace configuration via Terraform.
 
-This provider is currently in a _beta_ state. Please report any bugs.
+> [!IMPORTANT]
+> This is the v3 version of the terraform provider, which has various breaking changes from v1, as well as new functionality. It uses the new v3 version of the Stytch Management API and its respective Go SDK. If you are currently using v1, please read the [migration guide](./migrating_v1_to_v3.md).
 
 ## Documentation
 
@@ -26,7 +27,7 @@ terraform {
   required_providers {
     stytch = {
       source  = "stytchauth/stytch"
-      version = ">= 0.0.1" # Refer to docs for latest version
+      version = ">= 3.0.0" # Refer to docs for latest version
     }
   }
 }
@@ -37,6 +38,12 @@ provider "stytch" {}
 ```shell
 $ terraform init
 ```
+
+## Previous version support
+
+- The v1 version of the provider is still available in the Terraform registry and in the v1 branch of this repository.
+- As of November 17, 2025, the v1 version of the provider will not get any new features. Maintenance will be limited to major bug fixes and security upgrades. 
+- V1 will reach end of life **not before** June 30, 2026. A more detailed deprecation timeline will be published in our official docs.
 
 ## Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,13 @@ page_title: "stytch Provider"
 subcategory: ""
 description: |-
   Interact with Stytch's Programmatic Workspace Actions API https://stytch.com/docs/workspace-management/pwa/overview to configure your workspace, including projects, redirect URLs, email templates and more.
+  See migration instructions from v1 to v3 in the migration guide https://github.com/stytchauth/terraform-provider-stytch/blob/main/v1_to_v3_changes.md.
 ---
 
 # stytch Provider
 
-Interact with Stytch's [Programmatic Workspace Actions API](https://stytch.com/docs/workspace-management/pwa/overview) to configure your workspace, including projects, redirect URLs, email templates and more.
+Interact with Stytch's [Programmatic Workspace Actions API](https://stytch.com/docs/workspace-management/pwa/overview) to configure your workspace, including projects, redirect URLs, email templates and more. 
+ See migration instructions from v1 to v3 in the [migration guide](https://github.com/stytchauth/terraform-provider-stytch/blob/main/v1_to_v3_changes.md).
 
 ## Example Usage
 

--- a/docs/resources/event_log_streaming.md
+++ b/docs/resources/event_log_streaming.md
@@ -20,7 +20,7 @@ resource "stytch_event_log_streaming" "datadog" {
   destination_type = "DATADOG"
   enabled          = true
 
-  datadog = {
+  datadog_config = {
     site    = "US"
     api_key = var.datadog_api_key
   }
@@ -33,7 +33,7 @@ resource "stytch_event_log_streaming" "grafana" {
   destination_type = "GRAFANA_LOKI"
   enabled          = true
 
-  grafana_loki = {
+  grafana_loki_config = {
     hostname = "logs.example.com"
     username = "stytch-logs"
     password = var.grafana_loki_password
@@ -47,7 +47,7 @@ resource "stytch_event_log_streaming" "datadog_disabled" {
   destination_type = "DATADOG"
   enabled          = false
 
-  datadog = {
+  datadog_config = {
     site    = "EU"
     api_key = var.datadog_api_key
   }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -49,7 +49,7 @@ func (p *StytchProvider) Schema(
 	_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		Description: "Interact with Stytch's [Programmatic Workspace Actions API](https://stytch.com/docs/workspace-management/pwa/overview) to configure your workspace, including projects, redirect URLs, email templates and more.",
+		Description: "Interact with Stytch's [Programmatic Workspace Actions API](https://stytch.com/docs/workspace-management/pwa/overview) to configure your workspace, including projects, redirect URLs, email templates and more. \n See migration instructions from v1 to v3 in the [migration guide](https://github.com/stytchauth/terraform-provider-stytch/blob/main/v1_to_v3_changes.md).",
 		Attributes: map[string]schema.Attribute{
 			"workspace_key_id": schema.StringAttribute{
 				Description: "The key ID for a workspace management key obtained from the Stytch workspace management page",

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "3.0.0-alpha.4"
+const Version = "3.0.0"


### PR DESCRIPTION
## Description

- Move to v3.0.0
- Better README with callout about v3 version
- Include some information about limited continuous support for v1
- Add a link to the migration guide in the provider docs
- Missing tweak to the docs re: event log streaming attribute names