### PR TITLE
Expose environment.ProjectID for API auth

### DIFF
--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -80,6 +80,7 @@ resource "stytch_environment" "test_with_lock" {
 - `id` (String) A computed ID field used for Terraform resource management (format: project_slug.environment_slug).
 - `last_updated` (String) Timestamp of the last Terraform update.
 - `oauth_callback_id` (String) The callback ID used in OAuth requests for the environment.
+- `project_id` (String) The ID of the project this environment belongs to (used for API authentication).
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/stytchauth/stytch-management-go/v3 v3.0.0-alpha.5
+	github.com/stytchauth/stytch-management-go/v3 v3.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stytchauth/stytch-management-go/v3 v3.0.0-alpha.5 h1:nSf/6vsEu1GZ0E6ZQBfD/IHfCRRWts8PRmR9mafj3YQ=
-github.com/stytchauth/stytch-management-go/v3 v3.0.0-alpha.5/go.mod h1:k+FmnJeRGHSieasyPhrMDZiLQn2l8o/HiZVyCBKsznU=
+github.com/stytchauth/stytch-management-go/v3 v3.1.0 h1:6Q1/I467LPYAMYOQEqJDL7aUit7Kip96bKpqYhRff4w=
+github.com/stytchauth/stytch-management-go/v3 v3.1.0/go.mod h1:k+FmnJeRGHSieasyPhrMDZiLQn2l8o/HiZVyCBKsznU=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resources/environment.go
+++ b/internal/provider/resources/environment.go
@@ -38,6 +38,7 @@ type environmentResource struct {
 type environmentResourceModel struct {
 	ID                                                     types.String `tfsdk:"id"`
 	ProjectSlug                                            types.String `tfsdk:"project_slug"`
+	ProjectID                                              types.String `tfsdk:"project_id"`
 	EnvironmentSlug                                        types.String `tfsdk:"environment_slug"`
 	Name                                                   types.String `tfsdk:"name"`
 	OAuthCallbackID                                        types.String `tfsdk:"oauth_callback_id"`
@@ -91,6 +92,13 @@ func (r *environmentResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"project_id": schema.StringAttribute{
+				Description: "The ID of the project this environment belongs to (used for API authentication).",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"environment_slug": schema.StringAttribute{
@@ -209,6 +217,7 @@ func (r *environmentResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	ctx = tflog.SetField(ctx, "project_slug", plan.ProjectSlug.ValueString())
+	ctx = tflog.SetField(ctx, "project_id", plan.ProjectID.ValueString())
 	ctx = tflog.SetField(ctx, "environment_slug", plan.EnvironmentSlug.ValueString())
 	ctx = tflog.SetField(ctx, "environment_name", plan.Name.ValueString())
 	tflog.Info(ctx, "Creating test environment")
@@ -275,6 +284,7 @@ func (r *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	ctx = tflog.SetField(ctx, "project_slug", state.ProjectSlug.ValueString())
+	ctx = tflog.SetField(ctx, "project_id", state.ProjectID.ValueString())
 	ctx = tflog.SetField(ctx, "environment_slug", state.EnvironmentSlug.ValueString())
 	tflog.Info(ctx, "Reading environment")
 
@@ -321,6 +331,7 @@ func (r *environmentResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	ctx = tflog.SetField(ctx, "project_slug", state.ProjectSlug.ValueString())
+	ctx = tflog.SetField(ctx, "project_id", state.ProjectID.ValueString())
 	ctx = tflog.SetField(ctx, "environment_slug", state.EnvironmentSlug.ValueString())
 	tflog.Info(ctx, "Updating environment")
 
@@ -385,6 +396,7 @@ func (r *environmentResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	ctx = tflog.SetField(ctx, "project_slug", state.ProjectSlug.ValueString())
+	ctx = tflog.SetField(ctx, "project_id", state.ProjectID.ValueString())
 	ctx = tflog.SetField(ctx, "environment_slug", state.EnvironmentSlug.ValueString())
 	tflog.Info(ctx, "Deleting environment")
 
@@ -424,6 +436,7 @@ func refreshFromEnvironment(env environments.Environment) environmentResourceMod
 	return environmentResourceModel{
 		ID:                                  types.StringValue(fmt.Sprintf("%s.%s", env.ProjectSlug, env.EnvironmentSlug)),
 		ProjectSlug:                         types.StringValue(env.ProjectSlug),
+		ProjectID:                           types.StringValue(env.ProjectID),
 		EnvironmentSlug:                     types.StringValue(env.EnvironmentSlug),
 		Name:                                types.StringValue(env.Name),
 		OAuthCallbackID:                     types.StringValue(env.OAuthCallbackID),

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "3.0.1"
+const Version = "3.1.0"


### PR DESCRIPTION
# Description

Adds `project_id` as an output for the `environment` resource to be used in API auth.

# Testing
`make testacc`