### PR TITLE
Expose live project ID via project.live_environment.project_id

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -139,6 +139,7 @@ Read-Only:
 
 - `created_at` (String) The ISO-8601 timestamp when the environment was created.
 - `oauth_callback_id` (String) The callback ID used in OAuth requests for the environment.
+- `project_id` (String) The project ID for the live environment (used for API authentication).
 
 ## Import
 

--- a/internal/provider/resources/project.go
+++ b/internal/provider/resources/project.go
@@ -70,6 +70,7 @@ var projectResourceLegacySchema = schema.Schema{
 // See internal/provider/resources/environment.go environmentResourceModel.
 type environmentModel struct {
 	EnvironmentSlug                                        types.String `tfsdk:"environment_slug"`
+	ProjectID                                              types.String `tfsdk:"project_id"`
 	Name                                                   types.String `tfsdk:"name"`
 	OAuthCallbackID                                        types.String `tfsdk:"oauth_callback_id"`
 	CrossOrgPasswordsEnabled                               types.Bool   `tfsdk:"cross_org_passwords_enabled"`
@@ -86,6 +87,7 @@ type environmentModel struct {
 
 var environmentAttributeTypes = map[string]attr.Type{
 	"environment_slug":                        types.StringType,
+	"project_id":                              types.StringType,
 	"name":                                    types.StringType,
 	"oauth_callback_id":                       types.StringType,
 	"cross_org_passwords_enabled":             types.BoolType,
@@ -304,6 +306,13 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Default:     stringdefault.StaticString("production"),
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplace(),
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"project_id": schema.StringAttribute{
+						Description: "The project ID for the live environment (used for API authentication).",
+						Computed:    true,
+						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
 					},
@@ -771,6 +780,7 @@ func (r *projectResource) ImportState(ctx context.Context, req resource.ImportSt
 func refreshFromLiveEnv(env environments.Environment) environmentModel {
 	return environmentModel{
 		EnvironmentSlug:                     types.StringValue(env.EnvironmentSlug),
+		ProjectID:                           types.StringValue(env.ProjectID),
 		Name:                                types.StringValue(env.Name),
 		OAuthCallbackID:                     types.StringValue(env.OAuthCallbackID),
 		CrossOrgPasswordsEnabled:            types.BoolValue(env.CrossOrgPasswordsEnabled),

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "3.1.0"
+const Version = "3.2.0"


### PR DESCRIPTION
Follow up to #122

Verified locally:
```tf
resource "stytch_project" "minimal" {
  name     = "Terraform Test"
  vertical = "CONSUMER"
  
  live_environment = {
    name = "Production"
  }
}

output "live_project_id" {
  value = stytch_project.minimal.live_environment.project_id
}
```