### PR TITLE
Skip validation in sdk config if client isn't configured

### DIFF
--- a/internal/provider/resources/b2bsdkconfig.go
+++ b/internal/provider/resources/b2bsdkconfig.go
@@ -1047,6 +1047,12 @@ func (r *b2bSDKConfigResource) ValidateConfig(
 		return
 	}
 
+	// If the client has not been configured yet, skip validation. This can happen when
+	// ValidateConfig is called before the provider is fully configured.
+	if r.client == nil {
+		return
+	}
+
 	ctx = tflog.SetField(ctx, "project_slug", data.ProjectSlug.ValueString())
 	ctx = tflog.SetField(ctx, "environment_slug", data.EnvironmentSlug.ValueString())
 	tflog.Info(ctx, "Validating B2B SDK config")

--- a/internal/provider/resources/consumersdkconfig.go
+++ b/internal/provider/resources/consumersdkconfig.go
@@ -1191,6 +1191,12 @@ func (r *consumerSDKConfigResource) ValidateConfig(ctx context.Context, req reso
 		return
 	}
 
+	// If the client has not been configured yet, skip validation. This can happen when
+	// ValidateConfig is called before the provider is fully configured.
+	if r.client == nil {
+		return
+	}
+
 	ctx = tflog.SetField(ctx, "project_slug", data.ProjectSlug.ValueString())
 	ctx = tflog.SetField(ctx, "environment_slug", data.EnvironmentSlug.ValueString())
 	tflog.Info(ctx, "Validating Consumer SDK config")

--- a/internal/provider/version.go
+++ b/internal/provider/version.go
@@ -3,4 +3,4 @@ package provider
 // Version is the current version of the stytch terraform provider.
 // A GitHub action detects changes in this file in order to trigger
 // new releases to be tagged and built.
-const Version = "3.2.0"
+const Version = "3.2.1"


### PR DESCRIPTION
Addresses #128 

If the client hasn't been configured, skip validation. This is a similar pattern as in `Configure()`.