### PR TITLE
chore: migrate GitHub runners to ubuntu-latest-public

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   tag_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     outputs:
       diff: ${{ steps.diff.outputs.diff }}
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   goreleaser:
     needs: tag_release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     if: needs.tag_release.outputs.diff != 0
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
 
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
         run: make semgrep-ci
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     name: Check links in README.md
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Migrates all `ubuntu-latest` runner references to `ubuntu-latest-public` (org-scoped GitHub-hosted runner group).